### PR TITLE
Atualiza referências para novos nomes de repositórios

### DIFF
--- a/.github/workflows/android-build-scripts.yml
+++ b/.github/workflows/android-build-scripts.yml
@@ -145,8 +145,8 @@ jobs:
       - name: print ffbuild logs
         if: ${{ failure() }}
         run: '[[ -f ./src/ffmpeg/ffbuild/config.log ]] && tail -50 ./src/ffmpeg/ffbuild/config.log'
-  build-main-without-ffmpeg-kit-protocols-on-linux:
-    name: build without ffmpeg-kit protocols
+  build-main-without-ffmpeg-kit-lib-protocols-on-linux:
+    name: build without ffmpeg-kit-lib protocols
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -169,7 +169,7 @@ jobs:
           unzip -q -o ndk.zip -d .ndk
           echo "ANDROID_NDK_ROOT=$PWD/.ndk/$(ls .ndk)" >> $GITHUB_ENV
       - name: run the build script
-        run: ./android.sh --no-ffmpeg-kit-protocols --disable-x86 --disable-x86-64 --disable-arm-v7a --disable-arm-v7a-neon
+        run: ./android.sh --no-ffmpeg-kit-lib-protocols --disable-x86 --disable-x86-64 --disable-arm-v7a --disable-arm-v7a-neon
       - name: print build logs
         if: ${{ always() }}
         run: cat build.log

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,15 +6,15 @@ The following is a set of guidelines for contributing to `FFmpegKit`!
 
 ## Project Resources
 
-* [Wiki](https://github.com/arthenica/ffmpeg-kit/wiki) includes most detailed documentation we have
+* [Wiki](https://github.com/arthenica/ffmpeg-kit-lib/wiki) includes most detailed documentation we have
 * [FFmpegKit Feature Roadmap](https://github.com/orgs/arthenica/projects/1) shows our long term plans for the project
-* [How To Get Help](https://github.com/arthenica/ffmpeg-kit/issues/215) details what you need to do if you need help
-* [Discussions](https://github.com/arthenica/ffmpeg-kit/discussions) is where we expect you to ask questions
-* [Issues](https://github.com/arthenica/ffmpeg-kit/issues) is for bugs and issues
+* [How To Get Help](https://github.com/arthenica/ffmpeg-kit-lib/issues/215) details what you need to do if you need help
+* [Discussions](https://github.com/arthenica/ffmpeg-kit-lib/discussions) is where we expect you to ask questions
+* [Issues](https://github.com/arthenica/ffmpeg-kit-lib/issues) is for bugs and issues
 
 ## Reporting Bugs
 
-Bugs are tracked as [GitHub issues](https://github.com/arthenica/ffmpeg-kit/issues). We have a `Bug report` issue 
+Bugs are tracked as [GitHub issues](https://github.com/arthenica/ffmpeg-kit-lib/issues). We have a `Bug report` issue 
 template which includes all the fields we need to see to confirm a bug and work on it. Try to fill out all template
 fields, especially the logs field and steps to reproduce the bug. Reproducing a bug is crucial to be able to fix it.
 
@@ -52,7 +52,7 @@ the same from the pull requests as well. A feature must be implemented for all p
 feature.
 
 Ensure that your changes rely on official documented methods and test your changes using the test applications we have
-under the [ffmpeg-kit-test](https://github.com/arthenica/ffmpeg-kit-test) repository.
+under the [ffmpeg-kit-lib-test](https://github.com/arthenica/ffmpeg-kit-lib-test) repository.
 
 `main` branch of `FFmpegKit` includes only the latest released source code. Therefore, please open your pull requests
 against the development branches (`development` for native platforms, `development-react-native` for

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# FFmpegKit ![GitHub release](https://img.shields.io/badge/release-v6.0-blue.svg) ![Maven Central](https://img.shields.io/maven-central/v/com.arthenica/ffmpeg-kit-min) ![CocoaPods](https://img.shields.io/cocoapods/v/ffmpeg-kit-ios-min) ![pub](https://img.shields.io/pub/v/ffmpeg_kit_flutter.svg) ![npm](https://img.shields.io/npm/v/ffmpeg-kit-react-native.svg)
+# FFmpegKit ![GitHub release](https://img.shields.io/badge/release-v6.0-blue.svg) ![Maven Central](https://img.shields.io/maven-central/v/com.arthenica/ffmpeg-kit-lib-min) ![CocoaPods](https://img.shields.io/cocoapods/v/ffmpeg-kit-lib-ios-min) ![pub](https://img.shields.io/pub/v/ffmpeg_kit_flutter.svg) ![npm](https://img.shields.io/npm/v/ffmpeg-kit-lib-react-native.svg)
 
 ## Notice
-FFmpegKit has been officially retired. There will be no further `ffmpeg-kit` releases.
+FFmpegKit has been officially retired. There will be no further `ffmpeg-kit-lib` releases.
 
 See [Saying Goodbye to FFmpegKit @ medium](https://medium.com/@tanersener/saying-goodbye-to-ffmpegkit-33ae939767e1) to learn why we made this decision.
 
-All previously released `ffmpeg-kit` binaries will be removed according to the following schedule.
+All previously released `ffmpeg-kit-lib` binaries will be removed according to the following schedule.
 
 | FFmpegKit Version |  Available Until   |
 |:-----------------:|:------------------:|
@@ -14,12 +14,12 @@ All previously released `ffmpeg-kit` binaries will be removed according to the f
 
 Thank you for your support and interest in this project.
 
-<img src="https://github.com/arthenica/ffmpeg-kit/blob/main/docs/assets/ffmpeg-kit-icon-v9.png" width="240">
+<img src="https://github.com/arthenica/ffmpeg-kit-lib/blob/main/docs/assets/ffmpeg-kit-lib-icon-v9.png" width="240">
 
 `FFmpegKit` is a collection of tools to use `FFmpeg`<sup>1</sup> in `Android`, `iOS`, `Linux`, `macOS`, `tvOS`, `Flutter` and `React Native` applications.
 
 It includes scripts to build `FFmpeg` native libraries, a wrapper library to run `FFmpeg`/`FFprobe` commands in
- applications and 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit/releases),
+ applications and 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit-lib/releases),
  [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and [npm](https://www.npmjs.com).
 
 ### 1. Features
@@ -28,7 +28,7 @@ It includes scripts to build `FFmpeg` native libraries, a wrapper library to run
 - Supports native platforms: Android, iOS, Linux, macOS and tvOS
 - Supports hybrid platforms: Flutter, React Native
 - Based on FFmpeg `v4.5-dev` or later with optional system and external libraries
-- 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit/releases), [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and [npm](https://www.npmjs.com)
+- 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit-lib/releases), [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and [npm](https://www.npmjs.com)
 - Licensed under `LGPL 3.0` by default, `GPL v3.0` if GPL licensed libraries are enabled
 
 ### 2. Android
@@ -56,7 +56,7 @@ See [React Native](react-native) to learn more about `FFmpegKit` for `React Nati
 Use `android.sh`, `ios.sh`, `linux.sh`, `macos.sh` and `tvos.sh` to build `FFmpegKit` for each native platform.
 
 All scripts support additional options to enable optional libraries and disable platform architectures. See
-[Building](https://github.com/arthenica/ffmpeg-kit/wiki/Building) wiki page for the details.
+[Building](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Building) wiki page for the details.
 
 ### 8. FFmpegKit Library
 
@@ -70,13 +70,13 @@ a `JavaScript` API with `Typescript` definitions, which are identical in terms o
 
 ### 9. Packages
 
-There are eight different `ffmpeg-kit` packages distributed on 
-[Github](https://github.com/arthenica/ffmpeg-kit/releases), 
+There are eight different `ffmpeg-kit-lib` packages distributed on 
+[Github](https://github.com/arthenica/ffmpeg-kit-lib/releases), 
 [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and
  [npm](https://www.npmjs.com).
 Below you can see which system libraries and external libraries are enabled in each one of them.
 
-Please remember that some parts of `FFmpeg` are licensed under the `GPL` and only `GPL` licensed `ffmpeg-kit` packages 
+Please remember that some parts of `FFmpeg` are licensed under the `GPL` and only `GPL` licensed `ffmpeg-kit-lib` packages 
 include them.
 
 <table>
@@ -140,26 +140,26 @@ the exact version number of `FFmpeg` is obtained using the `git describe --tags`
 
 |    Platforms     |                                 FFmpegKit Version                                 | FFmpeg Version | Release Date |
 |:----------------:|:---------------------------------------------------------------------------------:|:--------------:|:------------:|
-|     Flutter      |   [6.0.3](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.3)    |      6.0       | Sep 19, 2023 |
-|   React Native   | [6.0.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.2) |      6.0       | Sep 19, 2023 |
-|     Flutter      |   [6.0.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.2)    |      6.0       | Sep 03, 2023 |
-|   React Native   | [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.1) |      6.0       | Sep 03, 2023 |
-|     Flutter      |   [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.1)    |      6.0       | Sep 03, 2023 |
-|   React Native   | [6.0.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.0) |      6.0       | Aug 27, 2023 |
-|     Flutter      |   [6.0.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.0)    |      6.0       | Aug 27, 2023 |
-|      Android<br>Apple       |         [6.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/v6.0)          |      6.0       | Aug 21, 2023 |
-|   React Native   | [5.1.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v5.1.0) |     5.1.2      | Oct 02, 2022 |
-|     Flutter      |   [5.1.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v5.1.0)    |     5.1.2      | Oct 02, 2022 |
-|     Android<br>Apple      |         [5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/v5.1)          |     5.1.2      | Sep 29, 2022 |
-|   React Native   | [4.5.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v4.5.2) |  4.5-dev-3393  | May 25, 2022 |
-|     Flutter      |   [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v4.5.1)    |  4.5-dev-3393  | Jan 02, 2022 |
-|   React Native   | [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v4.5.1) |  4.5-dev-3393  | Jan 02, 2022 |
-|     Android      |       [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.5.1)        |  4.5-dev-3393  | Jan 01, 2022 |
-|      Apple       |       [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.5.1)        |  4.5-dev-3393  | Dec 30, 2021 |
-|     Flutter      |   [4.5.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v4.5.0)    |  4.5-dev-2008  | Oct 05, 2021 |
-|   React Native   | [4.5.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v4.5.0) |  4.5-dev-2008  | Oct 01, 2021 |
-| Android<br>Apple |         [4.5](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.5)          |  4.5-dev-2008  | Sep 18, 2021 |
-| Android<br>Apple |         [4.4](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.4)          |  4.4-dev-3015  | Mar 03, 2021 |
+|     Flutter      |   [6.0.3](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.3)    |      6.0       | Sep 19, 2023 |
+|   React Native   | [6.0.2](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v6.0.2) |      6.0       | Sep 19, 2023 |
+|     Flutter      |   [6.0.2](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.2)    |      6.0       | Sep 03, 2023 |
+|   React Native   | [6.0.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v6.0.1) |      6.0       | Sep 03, 2023 |
+|     Flutter      |   [6.0.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.1)    |      6.0       | Sep 03, 2023 |
+|   React Native   | [6.0.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v6.0.0) |      6.0       | Aug 27, 2023 |
+|     Flutter      |   [6.0.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.0)    |      6.0       | Aug 27, 2023 |
+|      Android<br>Apple       |         [6.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v6.0)          |      6.0       | Aug 21, 2023 |
+|   React Native   | [5.1.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v5.1.0) |     5.1.2      | Oct 02, 2022 |
+|     Flutter      |   [5.1.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v5.1.0)    |     5.1.2      | Oct 02, 2022 |
+|     Android<br>Apple      |         [5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v5.1)          |     5.1.2      | Sep 29, 2022 |
+|   React Native   | [4.5.2](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v4.5.2) |  4.5-dev-3393  | May 25, 2022 |
+|     Flutter      |   [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v4.5.1)    |  4.5-dev-3393  | Jan 02, 2022 |
+|   React Native   | [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v4.5.1) |  4.5-dev-3393  | Jan 02, 2022 |
+|     Android      |       [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.5.1)        |  4.5-dev-3393  | Jan 01, 2022 |
+|      Apple       |       [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.5.1)        |  4.5-dev-3393  | Dec 30, 2021 |
+|     Flutter      |   [4.5.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v4.5.0)    |  4.5-dev-2008  | Oct 05, 2021 |
+|   React Native   | [4.5.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v4.5.0) |  4.5-dev-2008  | Oct 01, 2021 |
+| Android<br>Apple |         [4.5](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.5)          |  4.5-dev-2008  | Sep 18, 2021 |
+| Android<br>Apple |         [4.4](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.4)          |  4.4-dev-3015  | Mar 03, 2021 |
 
 ### 11. LTS Releases
 
@@ -193,12 +193,12 @@ This table shows the differences between two variants.
 
 ### 12. Documentation
 
-A more detailed documentation is available under [Wiki](https://github.com/arthenica/ffmpeg-kit/wiki).
+A more detailed documentation is available under [Wiki](https://github.com/arthenica/ffmpeg-kit-lib/wiki).
 
 ### 13. Test Applications
 
 You can see how `FFmpegKit` is used inside an application by running test applications created under 
-[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.
 
 All applications are identical and supports command execution, video encoding, accessing https urls, encoding audio,
 burning subtitles, video stabilisation, pipe operations and concurrent command execution.
@@ -218,8 +218,8 @@ libraries. Thus, `FFmpeg` libraries created by `FFmpegKit` are licensed under th
 `--enable-gpl` is provided they become subject to `GPL v3.0`. That is how prebuilt binaries with `-gpl` postfix are
 compiled.
 
-Refer to [Licenses](https://github.com/arthenica/ffmpeg-kit/wiki/Licenses) to see the licenses of all libraries.
-[Trademark](https://github.com/arthenica/ffmpeg-kit/wiki/Trademark) lists the trademarks used in the `FFmpegKit`
+Refer to [Licenses](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Licenses) to see the licenses of all libraries.
+[Trademark](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Trademark) lists the trademarks used in the `FFmpegKit`
 documentation.
 
 ### 15. Patents
@@ -229,7 +229,7 @@ include algorithms which are subject to software patents. If you live in a count
 patentable then you'll probably need to pay royalty fees to patent holders. We are not lawyers though, so we recommend
 that you seek legal advice first. See [FFmpeg Patent Mini-FAQ](https://ffmpeg.org/legal.html).
 
-`openh264` clearly states that it uses patented algorithms. Therefore, if you build `ffmpeg-kit` with `openh264` and
+`openh264` clearly states that it uses patented algorithms. Therefore, if you build `ffmpeg-kit-lib` with `openh264` and
 distribute that library, then you are subject to pay MPEG LA licensing fees. Refer to
 [OpenH264 FAQ](https://www.openh264.org/faq.html) page for the details.
 

--- a/android.sh
+++ b/android.sh
@@ -35,14 +35,14 @@ BUILD_TYPE_ID=""
 BUILD_VERSION=$(git describe --tags --always 2>>"${BASEDIR}"/build.log)
 
 # PROCESS LTS BUILD OPTION FIRST AND SET BUILD TYPE: MAIN OR LTS
-rm -f "${BASEDIR}"/android/ffmpeg-kit-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
-cp "${BASEDIR}"/tools/android/build.gradle "${BASEDIR}"/android/ffmpeg-kit-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
+rm -f "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
+cp "${BASEDIR}"/tools/android/build.gradle "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
 for argument in "$@"; do
   if [[ "$argument" == "-l" ]] || [[ "$argument" == "--lts" ]]; then
     enable_lts_build
     BUILD_TYPE_ID+="LTS "
-    rm -f "${BASEDIR}"/android/ffmpeg-kit-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
-    cp "${BASEDIR}"/tools/android/build.lts.gradle "${BASEDIR}"/android/ffmpeg-kit-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
+    rm -f "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
+    cp "${BASEDIR}"/tools/android/build.lts.gradle "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
   fi
 done
 
@@ -135,7 +135,7 @@ while [ ! $# -eq 0 ]; do
 
     export API=${API_LEVEL}
     ;;
-  --no-ffmpeg-kit-protocols)
+  --no-ffmpeg-kit-lib-protocols)
     export NO_FFMPEG_KIT_PROTOCOLS="1"
     ;;
   *)
@@ -175,11 +175,11 @@ if [[ -n ${DISPLAY_HELP} ]]; then
 fi
 
 # SET API LEVEL IN build.gradle
-${SED_INLINE} "s/minSdkVersion .*/minSdkVersion ${API}/g" "${BASEDIR}"/android/ffmpeg-kit-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
-${SED_INLINE} "s/versionCode ..0/versionCode ${API}0/g" "${BASEDIR}"/android/ffmpeg-kit-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
+${SED_INLINE} "s/minSdkVersion .*/minSdkVersion ${API}/g" "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
+${SED_INLINE} "s/versionCode ..0/versionCode ${API}0/g" "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build.gradle 1>>"${BASEDIR}"/build.log 2>&1
 
-echo -e "\nBuilding ffmpeg-kit ${BUILD_TYPE_ID}library for Android\n"
-echo -e -n "INFO: Building ffmpeg-kit ${BUILD_VERSION} ${BUILD_TYPE_ID}library for Android: " 1>>"${BASEDIR}"/build.log 2>&1
+echo -e "\nBuilding ffmpeg-kit-lib ${BUILD_TYPE_ID}library for Android\n"
+echo -e -n "INFO: Building ffmpeg-kit-lib ${BUILD_VERSION} ${BUILD_TYPE_ID}library for Android: " 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "$(date)\n" 1>>"${BASEDIR}"/build.log 2>&1
 
 # PRINT BUILD SUMMARY
@@ -278,7 +278,7 @@ fi
 # BUILD FFMPEG-KIT
 if [[ -n ${ANDROID_ARCHITECTURES} ]]; then
 
-  echo -n -e "\nffmpeg-kit: "
+  echo -n -e "\nffmpeg-kit-lib: "
 
   # CREATE Application.mk FILE BEFORE STARTING THE NATIVE BUILD
   build_application_mk
@@ -290,7 +290,7 @@ if [[ -n ${ANDROID_ARCHITECTURES} ]]; then
   cd "${BASEDIR}"/android 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
 
   # COPY EXTERNAL LIBRARY LICENSES
-  LICENSE_BASEDIR="${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/res/raw
+  LICENSE_BASEDIR="${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/res/raw
   rm -f "${LICENSE_BASEDIR}"/*.txt 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
   for library in {0..49}; do
     if [[ ${ENABLED_LIBRARIES[$library]} -eq 1 ]]; then
@@ -336,7 +336,7 @@ if [[ -n ${ANDROID_ARCHITECTURES} ]]; then
     cp "${BASEDIR}"/LICENSE "${LICENSE_BASEDIR}"/license.txt 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
   fi
 
-  echo -e "DEBUG: Copied the ffmpeg-kit license successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
+  echo -e "DEBUG: Copied the ffmpeg-kit-lib license successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
 
   overwrite_file "${BASEDIR}"/tools/source/SOURCE "${LICENSE_BASEDIR}"/source.txt 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
 
@@ -368,24 +368,24 @@ if [[ -n ${ANDROID_ARCHITECTURES} ]]; then
     echo -e -n "\nCreating Android archive under prebuilt: "
 
     # BUILD ANDROID ARCHIVE
-    rm -f "${BASEDIR}"/android/ffmpeg-kit-android-lib/build/outputs/aar/ffmpeg-kit-release.aar 1>>"${BASEDIR}"/build.log 2>&1
-    ./gradlew ffmpeg-kit-android-lib:clean ffmpeg-kit-android-lib:assembleRelease ffmpeg-kit-android-lib:testReleaseUnitTest 1>>"${BASEDIR}"/build.log 2>&1
+    rm -f "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build/outputs/aar/ffmpeg-kit-lib-release.aar 1>>"${BASEDIR}"/build.log 2>&1
+    ./gradlew ffmpeg-kit-lib-android-lib:clean ffmpeg-kit-lib-android-lib:assembleRelease ffmpeg-kit-lib-android-lib:testReleaseUnitTest 1>>"${BASEDIR}"/build.log 2>&1
     if [ $? -ne 0 ]; then
       echo -e "failed\n"
       exit 1
     fi
 
     # COPY ANDROID ARCHIVE TO PREBUILT DIRECTORY
-    FFMPEG_KIT_AAR="${BASEDIR}/prebuilt/$(get_aar_directory)/ffmpeg-kit"
+    FFMPEG_KIT_AAR="${BASEDIR}/prebuilt/$(get_aar_directory)/ffmpeg-kit-lib"
     rm -rf "${FFMPEG_KIT_AAR}" 1>>"${BASEDIR}"/build.log 2>&1
     mkdir -p "${FFMPEG_KIT_AAR}" 1>>"${BASEDIR}"/build.log 2>&1
-    cp "${BASEDIR}"/android/ffmpeg-kit-android-lib/build/outputs/aar/ffmpeg-kit-release.aar "${FFMPEG_KIT_AAR}"/ffmpeg-kit.aar 1>>"${BASEDIR}"/build.log 2>&1
+    cp "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/build/outputs/aar/ffmpeg-kit-lib-release.aar "${FFMPEG_KIT_AAR}"/ffmpeg-kit-lib.aar 1>>"${BASEDIR}"/build.log 2>&1
     if [ $? -ne 0 ]; then
       echo -e "failed\n"
       exit 1
     fi
 
-    echo -e "INFO: Created ffmpeg-kit Android archive successfully.\n" 1>>"${BASEDIR}"/build.log 2>&1
+    echo -e "INFO: Created ffmpeg-kit-lib Android archive successfully.\n" 1>>"${BASEDIR}"/build.log 2>&1
     echo -e "ok\n"
   else
     echo -e "INFO: Skipped creating Android archive.\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -4,5 +4,5 @@
 /.gradle/
 /libs/
 /obj/
-/ffmpeg-kit-android-lib/build/
+/ffmpeg-kit-lib-android-lib/build/
 *.tmp

--- a/android/README.md
+++ b/android/README.md
@@ -10,7 +10,7 @@
 
 ### 2. Building
 
-Run `android.sh` at project root directory to build `ffmpeg-kit` and `ffmpeg` shared libraries. 
+Run `android.sh` at project root directory to build `ffmpeg-kit-lib` and `ffmpeg` shared libraries. 
 
 Please note that `FFmpegKit` project repository includes the source code of `FFmpegKit` only. `android.sh` needs 
 network connectivity and internet access to `github.com` in order to download the source code of `FFmpeg` and 
@@ -22,7 +22,7 @@ external libraries enabled.
 
 ##### 2.1.1 Android Tools
    - Android SDK Build Tools
-   - Android NDK r22b or later with LLDB and CMake (See [#292](https://github.com/arthenica/ffmpeg-kit/issues/292) if you want to use NDK r23b or later)
+   - Android NDK r22b or later with LLDB and CMake (See [#292](https://github.com/arthenica/ffmpeg-kit-lib/issues/292) if you want to use NDK r23b or later)
 
 ##### 2.1.2 Packages
 
@@ -68,8 +68,8 @@ All libraries created by `android.sh` can be found under the `prebuilt` director
 #### 3.1 Android API
 
 1. Declare `mavenCentral` repository and add `FFmpegKit` dependency to your `build.gradle` in 
-   `ffmpeg-kit-<package name>` pattern. Use one of the `FFmpegKit` package names given in the 
-   project [README](https://github.com/arthenica/ffmpeg-kit).
+   `ffmpeg-kit-lib-<package name>` pattern. Use one of the `FFmpegKit` package names given in the 
+   project [README](https://github.com/arthenica/ffmpeg-kit-lib).
 
     ```yaml
     repositories {
@@ -77,7 +77,7 @@ All libraries created by `android.sh` can be found under the `prebuilt` director
     }
 
     dependencies {
-        implementation 'com.arthenica:ffmpeg-kit-full:6.0-2'
+        implementation 'com.arthenica:ffmpeg-kit-lib-full:6.0-2'
     }
     ```
 
@@ -328,4 +328,4 @@ All libraries created by `android.sh` can be found under the `prebuilt` director
 ### 4. Test Application
 
 You can see how `FFmpegKit` is used inside an application by running `Android` test applications developed under the
-[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.

--- a/android/ffmpeg-kit-android-lib/Doxyfile
+++ b/android/ffmpeg-kit-android-lib/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          =
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = ../../docs/assets/ffmpeg-kit-icon-v9-small.png
+PROJECT_LOGO           = ../../docs/assets/ffmpeg-kit-lib-icon-v9-small.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/android/ffmpeg-kit-android-lib/build.gradle
+++ b/android/ffmpeg-kit-android-lib/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdk 33
         versionCode 240600
         versionName "6.0"
-        project.archivesBaseName = "ffmpeg-kit"
+        project.archivesBaseName = "ffmpeg-kit-lib"
         consumerProguardFiles "consumer-rules.pro"
     }
 

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.h
@@ -30,7 +30,7 @@
 #define FFMPEG_KIT_VERSION "6.0"
 
 /** Defines tag used for Android logging. */
-#define LIB_NAME "ffmpeg-kit"
+#define LIB_NAME "ffmpeg-kit-lib"
 
 /** Verbose Android logging macro. */
 #define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LIB_NAME, __VA_ARGS__)

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_cmdutils.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_cmdutils.c
@@ -24,15 +24,15 @@
 /*
  * This file is the modified version of cmdutils.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_cmdutils.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_cmdutils.h
@@ -24,15 +24,15 @@
 /*
  * This file is the modified version of cmdutils.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg.c
@@ -28,9 +28,9 @@
 /*
  * This file is the modified version of ffmpeg.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 09.2023
  * --------------------------------------------------------
@@ -44,7 +44,7 @@
  * - forward_report method signature updated
  * - time field in report_callback/forward_report/set_report_callback updated as double
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg.h
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -33,7 +33,7 @@
  * - "class" member field renamed as clazz
  * - time field in set_report_callback updated as double
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_demux.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_demux.c
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg_demux.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_filter.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_filter.c
@@ -23,15 +23,15 @@
 /*
  * This file is the modified version of ffmpeg_filter.c file living in ffmpeg source code under the fftools folder.
  * We manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 08.2018
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_hw.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_hw.c
@@ -22,15 +22,15 @@
 /*
  * This file is the modified version of ffmpeg_hw.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 12.2019
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_mux.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_mux.c
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg_mux.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -32,7 +32,7 @@
  * - want_sdp marked as thread-local
  * - ms_from_ost migrated from ffmpeg_mux.c and marked as non-static
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_mux.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_mux.h
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of ffmpeg_mux.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_mux_init.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_mux_init.c
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of ffmpeg_mux_init.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_opt.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffmpeg_opt.c
@@ -23,9 +23,9 @@
 /*
  * This file is the modified version of ffmpeg_opt.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -33,7 +33,7 @@
  * - include fftools_ffmpeg_mux.h added
  * - fftools header names updated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 08.2020
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffprobe.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_ffprobe.c
@@ -28,16 +28,16 @@
 /*
  * This file is the modified version of ffprobe.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  * - fftools header names updated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_fopen_utf8.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_fopen_utf8.h
@@ -19,9 +19,9 @@
 /*
  * This file is the modified version of fopen_utf8.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  */
 
 #ifndef FFTOOLS_FOPEN_UTF8_H

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_objpool.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_objpool.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of objpool.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_objpool.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_objpool.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of objpool.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_opt_common.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_opt_common.c
@@ -23,15 +23,15 @@
 /*
  * This file is the modified version of opt_common.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - time field in report_callback updated as double
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_opt_common.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_opt_common.h
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of opt_common.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_sync_queue.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_sync_queue.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of sync_queue.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_sync_queue.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_sync_queue.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of sync_queue.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_thread_queue.c
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_thread_queue.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of thread_queue.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_thread_queue.h
+++ b/android/ffmpeg-kit-android-lib/src/main/cpp/fftools_thread_queue.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of thread_queue.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFmpegKitConfig.java
+++ b/android/ffmpeg-kit-android-lib/src/main/java/com/arthenica/ffmpegkit/FFmpegKitConfig.java
@@ -96,7 +96,7 @@ public class FFmpegKitConfig {
     /**
      * The tag used for logging.
      */
-    static final String TAG = "ffmpeg-kit";
+    static final String TAG = "ffmpeg-kit-lib";
 
     /**
      * Prefix of named pipes created by ffmpeg kit.
@@ -133,7 +133,7 @@ public class FFmpegKitConfig {
 
         Exceptions.registerRootPackage("com.arthenica");
 
-        android.util.Log.i(FFmpegKitConfig.TAG, "Loading ffmpeg-kit.");
+        android.util.Log.i(FFmpegKitConfig.TAG, "Loading ffmpeg-kit-lib.");
 
         final boolean nativeFFmpegTriedAndFailed = NativeLoader.loadFFmpeg();
 
@@ -173,7 +173,7 @@ public class FFmpegKitConfig {
         safFileDescriptorMap = new SparseArray<>();
         globalLogRedirectionStrategy = LogRedirectionStrategy.PRINT_LOGS_WHEN_NO_CALLBACKS_DEFINED;
 
-        android.util.Log.i(FFmpegKitConfig.TAG, String.format("Loaded ffmpeg-kit-%s-%s-%s-%s.", NativeLoader.loadPackageName(), NativeLoader.loadAbi(), NativeLoader.loadVersion(), NativeLoader.loadBuildDate()));
+        android.util.Log.i(FFmpegKitConfig.TAG, String.format("Loaded ffmpeg-kit-lib-%s-%s-%s-%s.", NativeLoader.loadPackageName(), NativeLoader.loadAbi(), NativeLoader.loadVersion(), NativeLoader.loadBuildDate()));
     }
 
     /**

--- a/android/ffmpeg-kit-android-lib/src/test/java/com/arthenica/ffmpegkit/FFmpegKitConfigTest.java
+++ b/android/ffmpeg-kit-android-lib/src/test/java/com/arthenica/ffmpegkit/FFmpegKitConfigTest.java
@@ -36,11 +36,11 @@ public class FFmpegKitConfigTest {
 
     private static final String externalLibrariesCommandOutput = "   configuration:\n" +
             "                          --cross-prefix=i686-linux-android-\n" +
-            "                          --sysroot=/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-i686/sysroot\n" +
-            "                          --prefix=/Users/taner/Projects/ffmpeg-kit/prebuilt/android-x86/ffmpeg\n" +
-            "                          --pkg-config=/usr/local/bin/pkg-config --extra-cflags='-march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32 -Wno-unused-function -fstrict-aliasing -fPIC -DANDROID -D__ANDROID__ -D__ANDROID_API__=21 -O2 -I/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-i686/sysroot/usr/include -I/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-i686/sysroot/usr/local/include'\n" +
+            "                          --sysroot=/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-lib-i686/sysroot\n" +
+            "                          --prefix=/Users/taner/Projects/ffmpeg-kit-lib/prebuilt/android-x86/ffmpeg\n" +
+            "                          --pkg-config=/usr/local/bin/pkg-config --extra-cflags='-march=i686 -mtune=intel -mssse3 -mfpmath=sse -m32 -Wno-unused-function -fstrict-aliasing -fPIC -DANDROID -D__ANDROID__ -D__ANDROID_API__=21 -O2 -I/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-lib-i686/sysroot/usr/include -I/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-lib-i686/sysroot/usr/local/include'\n" +
             "                          --extra-cxxflags='-std=c++11 -fno-exceptions -fno-rtti'\n" +
-            "                          --extra-ldflags='-march=i686 -Wl,--gc-sections,--icf=safe -lc -lm -ldl -llog -lc++_shared -L/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-i686/i686-linux-android/lib -L/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-i686/sysroot/usr/lib -L/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-i686/lib -L/Users/taner/Library/Android/sdk/ndk-bundle/platforms/android-21/arch-x86/usr/lib'\n" +
+            "                          --extra-ldflags='-march=i686 -Wl,--gc-sections,--icf=safe -lc -lm -ldl -llog -lc++_shared -L/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-lib-i686/i686-linux-android/lib -L/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-lib-i686/sysroot/usr/lib -L/Users/taner/Library/Android/sdk/ndk-bundle/toolchains/ffmpeg-kit-lib-i686/lib -L/Users/taner/Library/Android/sdk/ndk-bundle/platforms/android-21/arch-x86/usr/lib'\n" +
             "                          --enable-version3\n" +
             "                          --arch=i686\n" +
             "                          --cpu=i686\n" +

--- a/android/jni/Android.mk
+++ b/android/jni/Android.mk
@@ -32,7 +32,7 @@ FFMPEG_INCLUDES := $(MY_LOCAL_PATH)/../../prebuilt/$(MY_BUILD_DIR)/ffmpeg/includ
 
 MY_ARM_MODE := arm
 MY_ARM_NEON := false
-LOCAL_PATH := $(MY_LOCAL_PATH)/../ffmpeg-kit-android-lib/src/main/cpp
+LOCAL_PATH := $(MY_LOCAL_PATH)/../ffmpeg-kit-lib-android-lib/src/main/cpp
 
 # DEFINE ARCH FLAGS
 ifeq ($(TARGET_ARCH_ABI), armeabi-v7a)
@@ -84,7 +84,7 @@ MY_BUILD_GENERIC_FFMPEG_KIT := true
 
 ifeq ($(MY_ARMV7_NEON), true)
     include $(CLEAR_VARS)
-    LOCAL_PATH := $(MY_LOCAL_PATH)/../ffmpeg-kit-android-lib/src/main/cpp
+    LOCAL_PATH := $(MY_LOCAL_PATH)/../ffmpeg-kit-lib-android-lib/src/main/cpp
     LOCAL_ARM_MODE := $(MY_ARM_MODE)
     LOCAL_MODULE := ffmpegkit_armv7a_neon
     LOCAL_SRC_FILES := $(MY_SRC_FILES)
@@ -106,7 +106,7 @@ endif
 
 ifeq ($(MY_BUILD_GENERIC_FFMPEG_KIT), true)
     include $(CLEAR_VARS)
-    LOCAL_PATH := $(MY_LOCAL_PATH)/../ffmpeg-kit-android-lib/src/main/cpp
+    LOCAL_PATH := $(MY_LOCAL_PATH)/../ffmpeg-kit-lib-android-lib/src/main/cpp
     LOCAL_ARM_MODE := $(MY_ARM_MODE)
     LOCAL_MODULE := ffmpegkit
     LOCAL_SRC_FILES := $(MY_SRC_FILES)

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,2 +1,2 @@
-include ':ffmpeg-kit-android-lib'
-rootProject.name = 'ffmpeg-kit-android'
+include ':ffmpeg-kit-lib-android-lib'
+rootProject.name = 'ffmpeg-kit-lib-android'

--- a/apple.sh
+++ b/apple.sh
@@ -192,8 +192,8 @@ if [[ -n ${DISPLAY_HELP} ]]; then
   exit 0
 fi
 
-echo -e "\nBuilding ffmpeg-kit ${BUILD_TYPE_ID}umbrella xcframework\n"
-echo -e -n "INFO: Building ffmpeg-kit ${BUILD_VERSION} ${BUILD_TYPE_ID}umbrella xcframework: " 1>>"${BASEDIR}"/build.log 2>&1
+echo -e "\nBuilding ffmpeg-kit-lib ${BUILD_TYPE_ID}umbrella xcframework\n"
+echo -e -n "INFO: Building ffmpeg-kit-lib ${BUILD_VERSION} ${BUILD_TYPE_ID}umbrella xcframework: " 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "$(date)\n" 1>>"${BASEDIR}"/build.log 2>&1
 
 # PRINT BUILD SUMMARY

--- a/apple/Doxyfile
+++ b/apple/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          =
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = ../docs/assets/ffmpeg-kit-icon-v9-small.png
+PROJECT_LOGO           = ../docs/assets/ffmpeg-kit-lib-icon-v9-small.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/apple/README.md
+++ b/apple/README.md
@@ -29,7 +29,7 @@
 
 ### 2. Building
 
-Run `ios.sh`/`macos.sh`/`tvos.sh` inside the project root to build `ffmpeg-kit` and `ffmpeg` shared libraries
+Run `ios.sh`/`macos.sh`/`tvos.sh` inside the project root to build `ffmpeg-kit-lib` and `ffmpeg` shared libraries
 for a platform.
 
 Optionally, use `apple.sh` to combine bundles created by these three scripts in a single bundle.
@@ -105,22 +105,22 @@ All libraries created can be found under the `prebuilt` directory.
 
 #### 3.1 Objective API
 
-1. Add `FFmpegKit` dependency to your `Podfile` in `ffmpeg-kit-<platform>-<package name>` pattern. Use one of the 
-   `FFmpegKit` package names given in the project [README](https://github.com/arthenica/ffmpeg-kit).
+1. Add `FFmpegKit` dependency to your `Podfile` in `ffmpeg-kit-lib-<platform>-<package name>` pattern. Use one of the 
+   `FFmpegKit` package names given in the project [README](https://github.com/arthenica/ffmpeg-kit-lib).
 
     - iOS
     ```yaml
-    pod 'ffmpeg-kit-ios-full', '~> 6.0'
+    pod 'ffmpeg-kit-lib-ios-full', '~> 6.0'
     ```
 
     - macOS
     ```yaml
-    pod 'ffmpeg-kit-macos-full', '~> 6.0'
+    pod 'ffmpeg-kit-lib-macos-full', '~> 6.0'
     ```
 
     - tvOS
     ```yaml
-    pod 'ffmpeg-kit-tvos-full', '~> 6.0'
+    pod 'ffmpeg-kit-lib-tvos-full', '~> 6.0'
     ```
 
 2. Execute synchronous `FFmpeg` commands.
@@ -311,4 +311,4 @@ All libraries created can be found under the `prebuilt` directory.
 ### 4. Test Application
 
 You can see how `FFmpegKit` is used inside an application by running `iOS`, `macOS` and `tvOS` test applications 
-developed under the [FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+developed under the [FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.

--- a/apple/configure.ac
+++ b/apple/configure.ac
@@ -1,6 +1,6 @@
-# ffmpeg-kit 6.0 configure.ac
+# ffmpeg-kit-lib 6.0 configure.ac
 
-AC_INIT([ffmpeg-kit], [6.0], [https://github.com/arthenica/ffmpeg-kit/issues/new])
+AC_INIT([ffmpeg-kit-lib], [6.0], [https://github.com/arthenica/ffmpeg-kit-lib/issues/new])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/FFmpegKit.m])
 

--- a/apple/src/FFmpegKit.m
+++ b/apple/src/FFmpegKit.m
@@ -27,11 +27,11 @@
 @implementation FFmpegKit
 
 + (void)initialize {
-    NSLog(@"Loading ffmpeg-kit.\n");
+    NSLog(@"Loading ffmpeg-kit-lib.\n");
 
     [FFmpegKitConfig class];
 
-    NSLog(@"Loaded ffmpeg-kit-%@-%@-%@-%@.\n", [Packages getPackageName], [ArchDetect getArch], [FFmpegKitConfig getVersion], [FFmpegKitConfig getBuildDate]);
+    NSLog(@"Loaded ffmpeg-kit-lib-%@-%@-%@-%@.\n", [Packages getPackageName], [ArchDetect getArch], [FFmpegKitConfig getVersion], [FFmpegKitConfig getBuildDate]);
 }
 
 + (FFmpegSession*)executeWithArguments:(NSArray*)arguments {

--- a/apple/src/FFmpegKitConfig.m
+++ b/apple/src/FFmpegKitConfig.m
@@ -39,7 +39,7 @@
 NSString* const FFmpegKitVersion = @"6.0";
 
 /**
- * Prefix of named pipes created by ffmpeg-kit.
+ * Prefix of named pipes created by ffmpeg-kit-lib.
  */
 NSString* const FFmpegKitNamedPipePrefix = @"fk_pipe_";
 

--- a/apple/src/fftools_cmdutils.c
+++ b/apple/src/fftools_cmdutils.c
@@ -24,15 +24,15 @@
 /*
  * This file is the modified version of cmdutils.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_cmdutils.h
+++ b/apple/src/fftools_cmdutils.h
@@ -24,15 +24,15 @@
 /*
  * This file is the modified version of cmdutils.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg.c
+++ b/apple/src/fftools_ffmpeg.c
@@ -28,9 +28,9 @@
 /*
  * This file is the modified version of ffmpeg.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 09.2023
  * --------------------------------------------------------
@@ -44,7 +44,7 @@
  * - forward_report method signature updated
  * - time field in report_callback/forward_report/set_report_callback updated as double
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg.h
+++ b/apple/src/fftools_ffmpeg.h
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -33,7 +33,7 @@
  * - "class" member field renamed as clazz
  * - time field in set_report_callback updated as double
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_demux.c
+++ b/apple/src/fftools_ffmpeg_demux.c
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg_demux.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_filter.c
+++ b/apple/src/fftools_ffmpeg_filter.c
@@ -23,15 +23,15 @@
 /*
  * This file is the modified version of ffmpeg_filter.c file living in ffmpeg source code under the fftools folder.
  * We manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 08.2018
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_hw.c
+++ b/apple/src/fftools_ffmpeg_hw.c
@@ -22,15 +22,15 @@
 /*
  * This file is the modified version of ffmpeg_hw.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 12.2019
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_mux.c
+++ b/apple/src/fftools_ffmpeg_mux.c
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg_mux.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -32,7 +32,7 @@
  * - want_sdp marked as thread-local
  * - ms_from_ost migrated from ffmpeg_mux.c and marked as non-static
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_mux.h
+++ b/apple/src/fftools_ffmpeg_mux.h
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of ffmpeg_mux.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_mux_init.c
+++ b/apple/src/fftools_ffmpeg_mux_init.c
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of ffmpeg_mux_init.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_ffmpeg_opt.c
+++ b/apple/src/fftools_ffmpeg_opt.c
@@ -23,9 +23,9 @@
 /*
  * This file is the modified version of ffmpeg_opt.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -33,7 +33,7 @@
  * - include fftools_ffmpeg_mux.h added
  * - fftools header names updated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 08.2020
  * --------------------------------------------------------

--- a/apple/src/fftools_ffprobe.c
+++ b/apple/src/fftools_ffprobe.c
@@ -28,16 +28,16 @@
 /*
  * This file is the modified version of ffprobe.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  * - fftools header names updated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_fopen_utf8.h
+++ b/apple/src/fftools_fopen_utf8.h
@@ -19,9 +19,9 @@
 /*
  * This file is the modified version of fopen_utf8.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  */
 
 #ifndef FFTOOLS_FOPEN_UTF8_H

--- a/apple/src/fftools_objpool.c
+++ b/apple/src/fftools_objpool.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of objpool.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_objpool.h
+++ b/apple/src/fftools_objpool.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of objpool.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_opt_common.c
+++ b/apple/src/fftools_opt_common.c
@@ -23,15 +23,15 @@
 /*
  * This file is the modified version of opt_common.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - time field in report_callback updated as double
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_opt_common.h
+++ b/apple/src/fftools_opt_common.h
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of opt_common.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/apple/src/fftools_sync_queue.c
+++ b/apple/src/fftools_sync_queue.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of sync_queue.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_sync_queue.h
+++ b/apple/src/fftools_sync_queue.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of sync_queue.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_thread_queue.c
+++ b/apple/src/fftools_thread_queue.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of thread_queue.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/apple/src/fftools_thread_queue.h
+++ b/apple/src/fftools_thread_queue.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of thread_queue.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,6 @@
 # main section
-title: ffmpeg-kit
-baseurl: "/ffmpeg-kit"
+title: ffmpeg-kit-lib
+baseurl: "/ffmpeg-kit-lib"
 locale: "en"
 theme: jekyll-theme-minimal
 markdown: kramdown

--- a/docs/android/doc/html/annotated.html
+++ b/docs/android/doc/html/annotated.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/classes.html
+++ b/docs/android/doc/html/classes.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d0/d07/ffmpegkit__abidetect_8h.html
+++ b/docs/android/doc/html/d0/d07/ffmpegkit__abidetect_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d0/d07/ffmpegkit__abidetect_8h_source.html
+++ b/docs/android/doc/html/d0/d07/ffmpegkit__abidetect_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d0/d0f/struct_output_filter.html
+++ b/docs/android/doc/html/d0/d0f/struct_output_filter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d1/d9f/fftools__fopen__utf8_8h.html
+++ b/docs/android/doc/html/d1/d9f/fftools__fopen__utf8_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d1/d9f/fftools__fopen__utf8_8h_source.html
+++ b/docs/android/doc/html/d1/d9f/fftools__fopen__utf8_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -94,9 +94,9 @@ $(function() {
 <div class="line"><a id="l00019" name="l00019"></a><span class="lineno">   19</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment"> * This file is the modified version of fopen_utf8.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> */</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span> </div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="preprocessor">#ifndef FFTOOLS_FOPEN_UTF8_H</span></div>

--- a/docs/android/doc/html/d1/da2/struct_writer_context.html
+++ b/docs/android/doc/html/d1/da2/struct_writer_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d1/dba/fftools__ffmpeg__hw_8c.html
+++ b/docs/android/doc/html/d1/dba/fftools__ffmpeg__hw_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d1/dba/fftools__ffmpeg__hw_8c_source.html
+++ b/docs/android/doc/html/d1/dba/fftools__ffmpeg__hw_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,15 +97,15 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_hw.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 12.2019</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d1/ddd/ffprobekit_8c.html
+++ b/docs/android/doc/html/d1/ddd/ffprobekit_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d1/ddd/ffprobekit_8c_source.html
+++ b/docs/android/doc/html/d1/ddd/ffprobekit_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/d36/fftools__ffmpeg__filter_8c.html
+++ b/docs/android/doc/html/d2/d36/fftools__ffmpeg__filter_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/d36/fftools__ffmpeg__filter_8c_source.html
+++ b/docs/android/doc/html/d2/d36/fftools__ffmpeg__filter_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,15 +98,15 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of ffmpeg_filter.c file living in ffmpeg source code under the fftools folder.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * We manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * 08.2018</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d2/d50/fftools__opt__common_8h.html
+++ b/docs/android/doc/html/d2/d50/fftools__opt__common_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/d50/fftools__opt__common_8h_source.html
+++ b/docs/android/doc/html/d2/d50/fftools__opt__common_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of opt_common.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d2/d94/struct_sync_queue_stream.html
+++ b/docs/android/doc/html/d2/d94/struct_sync_queue_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/dbf/ffprobekit_8h.html
+++ b/docs/android/doc/html/d2/dbf/ffprobekit_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/dbf/ffprobekit_8h_source.html
+++ b/docs/android/doc/html/d2/dbf/ffprobekit_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/dc3/struct_callback_data.html
+++ b/docs/android/doc/html/d2/dc3/struct_callback_data.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d2/ddd/struct_compact_context.html
+++ b/docs/android/doc/html/d2/ddd/struct_compact_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d3/d1d/struct_option.html
+++ b/docs/android/doc/html/d3/d1d/struct_option.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d3/d6e/struct_input_stream.html
+++ b/docs/android/doc/html/d3/d6e/struct_input_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d3/da2/struct_keyframe_force_ctx.html
+++ b/docs/android/doc/html/d3/da2/struct_keyframe_force_ctx.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d3/dad/ffmpegkit__exception_8h.html
+++ b/docs/android/doc/html/d3/dad/ffmpegkit__exception_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d3/dad/ffmpegkit__exception_8h_source.html
+++ b/docs/android/doc/html/d3/dad/ffmpegkit__exception_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d3/db7/struct_flat_context.html
+++ b/docs/android/doc/html/d3/db7/struct_flat_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d4/d62/struct_obj_pool.html
+++ b/docs/android/doc/html/d4/d62/struct_obj_pool.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d4/da0/struct_default_context.html
+++ b/docs/android/doc/html/d4/da0/struct_default_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d4/dfd/struct_input_stream_1_1sub2video.html
+++ b/docs/android/doc/html/d4/dfd/struct_input_stream_1_1sub2video.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d5/d8e/struct_benchmark_time_stamps.html
+++ b/docs/android/doc/html/d5/d8e/struct_benchmark_time_stamps.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d5/d94/fftools__ffmpeg__mux_8c.html
+++ b/docs/android/doc/html/d5/d94/fftools__ffmpeg__mux_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d5/d94/fftools__ffmpeg__mux_8c_source.html
+++ b/docs/android/doc/html/d5/d94/fftools__ffmpeg__mux_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg_mux.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -107,7 +107,7 @@ $(function() {
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - want_sdp marked as thread-local</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - ms_from_ost migrated from ffmpeg_mux.c and marked as non-static</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d5/df5/fftools__objpool_8h.html
+++ b/docs/android/doc/html/d5/df5/fftools__objpool_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d5/df5/fftools__objpool_8h_source.html
+++ b/docs/android/doc/html/d5/df5/fftools__objpool_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of objpool.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d6/d16/struct_mux_stream.html
+++ b/docs/android/doc/html/d6/d16/struct_mux_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d6/d1f/saf__wrapper_8h.html
+++ b/docs/android/doc/html/d6/d1f/saf__wrapper_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Android API
    &#160;<span id="projectnumber">4.4</span>

--- a/docs/android/doc/html/d6/d1f/saf__wrapper_8h_source.html
+++ b/docs/android/doc/html/d6/d1f/saf__wrapper_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Android API
    &#160;<span id="projectnumber">4.4</span>

--- a/docs/android/doc/html/d6/d2c/struct_audio_channel_map.html
+++ b/docs/android/doc/html/d6/d2c/struct_audio_channel_map.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d6/d35/fftools__sync__queue_8h.html
+++ b/docs/android/doc/html/d6/d35/fftools__sync__queue_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d6/d35/fftools__sync__queue_8h_source.html
+++ b/docs/android/doc/html/d6/d35/fftools__sync__queue_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of sync_queue.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d6/d53/struct_j_s_o_n_context.html
+++ b/docs/android/doc/html/d6/d53/struct_j_s_o_n_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d6/d69/struct_option_group.html
+++ b/docs/android/doc/html/d6/d69/struct_option_group.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d6/dff/struct_writer.html
+++ b/docs/android/doc/html/d6/dff/struct_writer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/d0c/struct_input_filter.html
+++ b/docs/android/doc/html/d7/d0c/struct_input_filter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/d48/fftools__ffmpeg_8c.html
+++ b/docs/android/doc/html/d7/d48/fftools__ffmpeg_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/d48/fftools__ffmpeg_8c_source.html
+++ b/docs/android/doc/html/d7/d48/fftools__ffmpeg_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,9 +98,9 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * This file is the modified version of ffmpeg.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -110,7 +110,7 @@ $(function() {
 <div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * - forward_report method signature updated</span></div>
 <div class="line"><a id="l00041" name="l00041"></a><span class="lineno">   41</span><span class="comment"> * - time field in report_callback/forward_report/set_report_callback updated as double</span></div>
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00044" name="l00044"></a><span class="lineno">   44</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00045" name="l00045"></a><span class="lineno">   45</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00046" name="l00046"></a><span class="lineno">   46</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d7/d4f/struct_option_group_list.html
+++ b/docs/android/doc/html/d7/d4f/struct_option_group_list.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/d60/struct_frame_data.html
+++ b/docs/android/doc/html/d7/d60/struct_frame_data.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/db2/struct_x_m_l_context.html
+++ b/docs/android/doc/html/d7/db2/struct_x_m_l_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/db3/fftools__ffmpeg_8h.html
+++ b/docs/android/doc/html/d7/db3/fftools__ffmpeg_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/db3/fftools__ffmpeg_8h_source.html
+++ b/docs/android/doc/html/d7/db3/fftools__ffmpeg_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -108,7 +108,7 @@ $(function() {
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - &quot;class&quot; member field renamed as clazz</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * - time field in set_report_callback updated as double</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d7/dc9/struct_demuxer.html
+++ b/docs/android/doc/html/d7/dc9/struct_demuxer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/dcc/fftools__cmdutils_8c.html
+++ b/docs/android/doc/html/d7/dcc/fftools__cmdutils_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/dcc/fftools__cmdutils_8c_source.html
+++ b/docs/android/doc/html/d7/dcc/fftools__cmdutils_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -99,15 +99,15 @@ $(function() {
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * This file is the modified version of cmdutils.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d7/dd8/fftools__objpool_8c.html
+++ b/docs/android/doc/html/d7/dd8/fftools__objpool_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d7/dd8/fftools__objpool_8c_source.html
+++ b/docs/android/doc/html/d7/dd8/fftools__objpool_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of objpool.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d8/d4e/fftools__cmdutils_8h.html
+++ b/docs/android/doc/html/d8/d4e/fftools__cmdutils_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d8/d4e/fftools__cmdutils_8h_source.html
+++ b/docs/android/doc/html/d8/d4e/fftools__cmdutils_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -99,15 +99,15 @@ $(function() {
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * This file is the modified version of cmdutils.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d8/d59/fftools__ffmpeg__mux__init_8c.html
+++ b/docs/android/doc/html/d8/d59/fftools__ffmpeg__mux__init_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d8/d59/fftools__ffmpeg__mux__init_8c_source.html
+++ b/docs/android/doc/html/d8/d59/fftools__ffmpeg__mux__init_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_mux_init.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d8/d78/fftools__ffprobe_8c.html
+++ b/docs/android/doc/html/d8/d78/fftools__ffprobe_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d8/d78/fftools__ffprobe_8c_source.html
+++ b/docs/android/doc/html/d8/d78/fftools__ffprobe_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,16 +98,16 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * This file is the modified version of ffprobe.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * - fftools header names updated</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00041" name="l00041"></a><span class="lineno">   41</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d8/d99/struct_input_file.html
+++ b/docs/android/doc/html/d8/d99/struct_input_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d8/dee/ffmpegkit_8h.html
+++ b/docs/android/doc/html/d8/dee/ffmpegkit_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -83,7 +83,7 @@ $(function() {
 Macros</h2></td></tr>
 <tr class="memitem:a06660f2006f6064ab855b6f7f10f9927"><td class="memItemLeft" align="right" valign="top">#define&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="../../d8/dee/ffmpegkit_8h.html#a06660f2006f6064ab855b6f7f10f9927">FFMPEG_KIT_VERSION</a>&#160;&#160;&#160;&quot;6.0&quot;</td></tr>
 <tr class="separator:a06660f2006f6064ab855b6f7f10f9927"><td class="memSeparator" colspan="2">&#160;</td></tr>
-<tr class="memitem:a6e43beaa714b1bf01ce2271440786e38"><td class="memItemLeft" align="right" valign="top">#define&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="../../d8/dee/ffmpegkit_8h.html#a6e43beaa714b1bf01ce2271440786e38">LIB_NAME</a>&#160;&#160;&#160;&quot;ffmpeg-kit&quot;</td></tr>
+<tr class="memitem:a6e43beaa714b1bf01ce2271440786e38"><td class="memItemLeft" align="right" valign="top">#define&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="../../d8/dee/ffmpegkit_8h.html#a6e43beaa714b1bf01ce2271440786e38">LIB_NAME</a>&#160;&#160;&#160;&quot;ffmpeg-kit-lib&quot;</td></tr>
 <tr class="separator:a6e43beaa714b1bf01ce2271440786e38"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:ab78bd305488c62caf8515ee765b1ed49"><td class="memItemLeft" align="right" valign="top">#define&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="../../d8/dee/ffmpegkit_8h.html#ab78bd305488c62caf8515ee765b1ed49">LOGV</a>(...)&#160;&#160;&#160;__android_log_print(ANDROID_LOG_VERBOSE, <a class="el" href="../../d8/dee/ffmpegkit_8h.html#a6e43beaa714b1bf01ce2271440786e38">LIB_NAME</a>, __VA_ARGS__)</td></tr>
 <tr class="separator:ab78bd305488c62caf8515ee765b1ed49"><td class="memSeparator" colspan="2">&#160;</td></tr>
@@ -150,7 +150,7 @@ Functions</h2></td></tr>
 <div class="memproto">
       <table class="memname">
         <tr>
-          <td class="memname">#define LIB_NAME&#160;&#160;&#160;&quot;ffmpeg-kit&quot;</td>
+          <td class="memname">#define LIB_NAME&#160;&#160;&#160;&quot;ffmpeg-kit-lib&quot;</td>
         </tr>
       </table>
 </div><div class="memdoc">

--- a/docs/android/doc/html/d8/dee/ffmpegkit_8h_source.html
+++ b/docs/android/doc/html/d8/dee/ffmpegkit_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -103,7 +103,7 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span> </div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno"><a class="line" href="../../d8/dee/ffmpegkit_8h.html#a06660f2006f6064ab855b6f7f10f9927">   30</a></span><span class="preprocessor">#define FFMPEG_KIT_VERSION &quot;6.0&quot;</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span> </div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno"><a class="line" href="../../d8/dee/ffmpegkit_8h.html#a6e43beaa714b1bf01ce2271440786e38">   33</a></span><span class="preprocessor">#define LIB_NAME &quot;ffmpeg-kit&quot;</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno"><a class="line" href="../../d8/dee/ffmpegkit_8h.html#a6e43beaa714b1bf01ce2271440786e38">   33</a></span><span class="preprocessor">#define LIB_NAME &quot;ffmpeg-kit-lib&quot;</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span> </div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno"><a class="line" href="../../d8/dee/ffmpegkit_8h.html#ab78bd305488c62caf8515ee765b1ed49">   36</a></span><span class="preprocessor">#define LOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LIB_NAME, __VA_ARGS__)</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span> </div>

--- a/docs/android/doc/html/d8/dee/struct_read_interval.html
+++ b/docs/android/doc/html/d8/dee/struct_read_interval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d11/structsection.html
+++ b/docs/android/doc/html/d9/d11/structsection.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d28/fftools__ffmpeg__demux_8c.html
+++ b/docs/android/doc/html/d9/d28/fftools__ffmpeg__demux_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d28/fftools__ffmpeg__demux_8c_source.html
+++ b/docs/android/doc/html/d9/d28/fftools__ffmpeg__demux_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg_demux.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/d9/d28/struct_sync_queue.html
+++ b/docs/android/doc/html/d9/d28/struct_sync_queue.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d56/ffmpegkit__exception_8c.html
+++ b/docs/android/doc/html/d9/d56/ffmpegkit__exception_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d56/ffmpegkit__exception_8c_source.html
+++ b/docs/android/doc/html/d9/d56/ffmpegkit__exception_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d59/saf__wrapper_8c.html
+++ b/docs/android/doc/html/d9/d59/saf__wrapper_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Android API
    &#160;<span id="projectnumber">4.4</span>

--- a/docs/android/doc/html/d9/d59/saf__wrapper_8c_source.html
+++ b/docs/android/doc/html/d9/d59/saf__wrapper_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Android API
    &#160;<span id="projectnumber">4.4</span>

--- a/docs/android/doc/html/d9/d6c/struct_demux_msg.html
+++ b/docs/android/doc/html/d9/d6c/struct_demux_msg.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/d6d/structunit__value.html
+++ b/docs/android/doc/html/d9/d6d/structunit__value.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/db4/struct_thread_queue.html
+++ b/docs/android/doc/html/d9/db4/struct_thread_queue.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/d9/de7/struct_filter_graph.html
+++ b/docs/android/doc/html/d9/de7/struct_filter_graph.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d2c/fftools__opt__common_8c.html
+++ b/docs/android/doc/html/da/d2c/fftools__opt__common_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d2c/fftools__opt__common_8c_source.html
+++ b/docs/android/doc/html/da/d2c/fftools__opt__common_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,15 +98,15 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of opt_common.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - time field in report_callback updated as double</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/da/d4f/struct_i_n_i_context.html
+++ b/docs/android/doc/html/da/d4f/struct_i_n_i_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d56/struct_enc_stats_file.html
+++ b/docs/android/doc/html/da/d56/struct_enc_stats_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d62/struct_fifo_elem.html
+++ b/docs/android/doc/html/da/d62/struct_fifo_elem.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d66/fftools__ffmpeg__opt_8c.html
+++ b/docs/android/doc/html/da/d66/fftools__ffmpeg__opt_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d66/fftools__ffmpeg__opt_8c_source.html
+++ b/docs/android/doc/html/da/d66/fftools__ffmpeg__opt_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,9 +98,9 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of ffmpeg_opt.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -108,7 +108,7 @@ $(function() {
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - include fftools_ffmpeg_mux.h added</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * - fftools header names updated</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * 08.2020</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/da/d87/fftools__thread__queue_8h.html
+++ b/docs/android/doc/html/da/d87/fftools__thread__queue_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d87/fftools__thread__queue_8h_source.html
+++ b/docs/android/doc/html/da/d87/fftools__thread__queue_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of thread_queue.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/da/d94/ffmpegkit__abidetect_8c.html
+++ b/docs/android/doc/html/da/d94/ffmpegkit__abidetect_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/da/d94/ffmpegkit__abidetect_8c_source.html
+++ b/docs/android/doc/html/da/d94/ffmpegkit__abidetect_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/db/d60/struct_stream_map.html
+++ b/docs/android/doc/html/db/d60/struct_stream_map.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/db/db5/struct_option_parse_context.html
+++ b/docs/android/doc/html/db/db5/struct_option_parse_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/db/dbb/struct_enc_stats.html
+++ b/docs/android/doc/html/db/dbb/struct_enc_stats.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/db/dd7/struct_option_group_def.html
+++ b/docs/android/doc/html/db/dd7/struct_option_group_def.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/db/dde/struct_output_stream.html
+++ b/docs/android/doc/html/db/dde/struct_output_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dc/d16/struct_last_frame_duration.html
+++ b/docs/android/doc/html/dc/d16/struct_last_frame_duration.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dc/d1e/struct_option_def.html
+++ b/docs/android/doc/html/dc/d1e/struct_option_def.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dc/d56/fftools__thread__queue_8c.html
+++ b/docs/android/doc/html/dc/d56/fftools__thread__queue_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dc/d56/fftools__thread__queue_8c_source.html
+++ b/docs/android/doc/html/dc/d56/fftools__thread__queue_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of thread_queue.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/dc/dd3/ffmpegkit_8c.html
+++ b/docs/android/doc/html/dc/dd3/ffmpegkit_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dc/dd3/ffmpegkit_8c_source.html
+++ b/docs/android/doc/html/dc/dd3/ffmpegkit_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dc/df8/union_sync_queue_frame.html
+++ b/docs/android/doc/html/dc/df8/union_sync_queue_frame.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dd/d0c/struct_enc_stats_component.html
+++ b/docs/android/doc/html/dd/d0c/struct_enc_stats_component.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dd/d15/struct_log_buffer.html
+++ b/docs/android/doc/html/dd/d15/struct_log_buffer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/dd/da5/struct_specifier_opt.html
+++ b/docs/android/doc/html/dd/da5/struct_specifier_opt.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/de/d29/struct_muxer.html
+++ b/docs/android/doc/html/de/d29/struct_muxer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/de/dc7/struct_h_w_device.html
+++ b/docs/android/doc/html/de/dc7/struct_h_w_device.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/de/df2/struct_output_file.html
+++ b/docs/android/doc/html/de/df2/struct_output_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/df/d2b/fftools__ffmpeg__mux_8h.html
+++ b/docs/android/doc/html/df/d2b/fftools__ffmpeg__mux_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/df/d2b/fftools__ffmpeg__mux_8h_source.html
+++ b/docs/android/doc/html/df/d2b/fftools__ffmpeg__mux_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_mux.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/df/d37/struct_h_w_accel.html
+++ b/docs/android/doc/html/df/d37/struct_h_w_accel.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/android/doc/html/df/d77/struct_options_context.html
+++ b/docs/android/doc/html/df/d77/struct_options_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/df/dbb/fftools__sync__queue_8c.html
+++ b/docs/android/doc/html/df/dbb/fftools__sync__queue_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/df/dbb/fftools__sync__queue_8c_source.html
+++ b/docs/android/doc/html/df/dbb/fftools__sync__queue_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of sync_queue.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/android/doc/html/df/dff/android__lts__support_8c.html
+++ b/docs/android/doc/html/df/dff/android__lts__support_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/df/dff/android__lts__support_8c_source.html
+++ b/docs/android/doc/html/df/dff/android__lts__support_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/files.html
+++ b/docs/android/doc/html/files.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions.html
+++ b/docs/android/doc/html/functions.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_b.html
+++ b/docs/android/doc/html/functions_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_c.html
+++ b/docs/android/doc/html/functions_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_d.html
+++ b/docs/android/doc/html/functions_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_e.html
+++ b/docs/android/doc/html/functions_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_f.html
+++ b/docs/android/doc/html/functions_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_g.html
+++ b/docs/android/doc/html/functions_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_h.html
+++ b/docs/android/doc/html/functions_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_i.html
+++ b/docs/android/doc/html/functions_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_k.html
+++ b/docs/android/doc/html/functions_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_l.html
+++ b/docs/android/doc/html/functions_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_m.html
+++ b/docs/android/doc/html/functions_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_n.html
+++ b/docs/android/doc/html/functions_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_o.html
+++ b/docs/android/doc/html/functions_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_p.html
+++ b/docs/android/doc/html/functions_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_q.html
+++ b/docs/android/doc/html/functions_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_r.html
+++ b/docs/android/doc/html/functions_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_s.html
+++ b/docs/android/doc/html/functions_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_t.html
+++ b/docs/android/doc/html/functions_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_u.html
+++ b/docs/android/doc/html/functions_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_v.html
+++ b/docs/android/doc/html/functions_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars.html
+++ b/docs/android/doc/html/functions_vars.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_b.html
+++ b/docs/android/doc/html/functions_vars_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_c.html
+++ b/docs/android/doc/html/functions_vars_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_d.html
+++ b/docs/android/doc/html/functions_vars_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_e.html
+++ b/docs/android/doc/html/functions_vars_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_f.html
+++ b/docs/android/doc/html/functions_vars_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_g.html
+++ b/docs/android/doc/html/functions_vars_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_h.html
+++ b/docs/android/doc/html/functions_vars_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_i.html
+++ b/docs/android/doc/html/functions_vars_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_k.html
+++ b/docs/android/doc/html/functions_vars_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_l.html
+++ b/docs/android/doc/html/functions_vars_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_m.html
+++ b/docs/android/doc/html/functions_vars_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_n.html
+++ b/docs/android/doc/html/functions_vars_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_o.html
+++ b/docs/android/doc/html/functions_vars_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_p.html
+++ b/docs/android/doc/html/functions_vars_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_q.html
+++ b/docs/android/doc/html/functions_vars_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_r.html
+++ b/docs/android/doc/html/functions_vars_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_s.html
+++ b/docs/android/doc/html/functions_vars_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_t.html
+++ b/docs/android/doc/html/functions_vars_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_u.html
+++ b/docs/android/doc/html/functions_vars_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_v.html
+++ b/docs/android/doc/html/functions_vars_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_w.html
+++ b/docs/android/doc/html/functions_vars_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_vars_x.html
+++ b/docs/android/doc/html/functions_vars_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_w.html
+++ b/docs/android/doc/html/functions_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/functions_x.html
+++ b/docs/android/doc/html/functions_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals.html
+++ b/docs/android/doc/html/globals.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_b.html
+++ b/docs/android/doc/html/globals_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_c.html
+++ b/docs/android/doc/html/globals_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_d.html
+++ b/docs/android/doc/html/globals_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_defs.html
+++ b/docs/android/doc/html/globals_defs.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_e.html
+++ b/docs/android/doc/html/globals_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_enum.html
+++ b/docs/android/doc/html/globals_enum.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_eval.html
+++ b/docs/android/doc/html/globals_eval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_f.html
+++ b/docs/android/doc/html/globals_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func.html
+++ b/docs/android/doc/html/globals_func.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_b.html
+++ b/docs/android/doc/html/globals_func_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_c.html
+++ b/docs/android/doc/html/globals_func_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_d.html
+++ b/docs/android/doc/html/globals_func_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_e.html
+++ b/docs/android/doc/html/globals_func_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_f.html
+++ b/docs/android/doc/html/globals_func_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_g.html
+++ b/docs/android/doc/html/globals_func_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_h.html
+++ b/docs/android/doc/html/globals_func_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_i.html
+++ b/docs/android/doc/html/globals_func_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_j.html
+++ b/docs/android/doc/html/globals_func_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_l.html
+++ b/docs/android/doc/html/globals_func_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_m.html
+++ b/docs/android/doc/html/globals_func_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_n.html
+++ b/docs/android/doc/html/globals_func_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_o.html
+++ b/docs/android/doc/html/globals_func_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_p.html
+++ b/docs/android/doc/html/globals_func_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_q.html
+++ b/docs/android/doc/html/globals_func_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_r.html
+++ b/docs/android/doc/html/globals_func_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_s.html
+++ b/docs/android/doc/html/globals_func_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_t.html
+++ b/docs/android/doc/html/globals_func_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_u.html
+++ b/docs/android/doc/html/globals_func_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_v.html
+++ b/docs/android/doc/html/globals_func_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_w.html
+++ b/docs/android/doc/html/globals_func_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_func_x.html
+++ b/docs/android/doc/html/globals_func_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_g.html
+++ b/docs/android/doc/html/globals_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_h.html
+++ b/docs/android/doc/html/globals_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_i.html
+++ b/docs/android/doc/html/globals_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_j.html
+++ b/docs/android/doc/html/globals_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_k.html
+++ b/docs/android/doc/html/globals_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_l.html
+++ b/docs/android/doc/html/globals_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_m.html
+++ b/docs/android/doc/html/globals_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_n.html
+++ b/docs/android/doc/html/globals_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_o.html
+++ b/docs/android/doc/html/globals_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_p.html
+++ b/docs/android/doc/html/globals_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_q.html
+++ b/docs/android/doc/html/globals_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_r.html
+++ b/docs/android/doc/html/globals_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_s.html
+++ b/docs/android/doc/html/globals_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_t.html
+++ b/docs/android/doc/html/globals_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_type.html
+++ b/docs/android/doc/html/globals_type.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_u.html
+++ b/docs/android/doc/html/globals_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_v.html
+++ b/docs/android/doc/html/globals_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars.html
+++ b/docs/android/doc/html/globals_vars.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_b.html
+++ b/docs/android/doc/html/globals_vars_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_c.html
+++ b/docs/android/doc/html/globals_vars_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_d.html
+++ b/docs/android/doc/html/globals_vars_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_e.html
+++ b/docs/android/doc/html/globals_vars_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_f.html
+++ b/docs/android/doc/html/globals_vars_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_g.html
+++ b/docs/android/doc/html/globals_vars_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_h.html
+++ b/docs/android/doc/html/globals_vars_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_i.html
+++ b/docs/android/doc/html/globals_vars_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_j.html
+++ b/docs/android/doc/html/globals_vars_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_k.html
+++ b/docs/android/doc/html/globals_vars_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_l.html
+++ b/docs/android/doc/html/globals_vars_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_m.html
+++ b/docs/android/doc/html/globals_vars_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_n.html
+++ b/docs/android/doc/html/globals_vars_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_o.html
+++ b/docs/android/doc/html/globals_vars_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_p.html
+++ b/docs/android/doc/html/globals_vars_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_q.html
+++ b/docs/android/doc/html/globals_vars_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_r.html
+++ b/docs/android/doc/html/globals_vars_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_s.html
+++ b/docs/android/doc/html/globals_vars_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_t.html
+++ b/docs/android/doc/html/globals_vars_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_u.html
+++ b/docs/android/doc/html/globals_vars_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_v.html
+++ b/docs/android/doc/html/globals_vars_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_w.html
+++ b/docs/android/doc/html/globals_vars_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_vars_x.html
+++ b/docs/android/doc/html/globals_vars_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_w.html
+++ b/docs/android/doc/html/globals_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/globals_x.html
+++ b/docs/android/doc/html/globals_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/doc/html/index.html
+++ b/docs/android/doc/html/index.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Android API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/android/javadoc/index.html
+++ b/docs/android/javadoc/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <!-- NewPage -->
 <html lang="en"><head>
-    <title>:ffmpeg-kit-android-lib </title>
+    <title>:ffmpeg-kit-lib-android-lib </title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="dc.created" content="2020-03-25">
     <link rel="stylesheet" type="text/css" href="stylesheet.css" title="Style">
@@ -87,7 +87,7 @@ var pathtoroot = "";
 </header>
 <main role="main">
     <div class="header">
-        <h1 class="title">:ffmpeg-kit-android-lib </h1>
+        <h1 class="title">:ffmpeg-kit-lib-android-lib </h1>
     </div>
         <div class="header">
             <div class="subtitle">

--- a/docs/android/javadoc/module-search-index.js
+++ b/docs/android/javadoc/module-search-index.js
@@ -1,1 +1,1 @@
-var moduleSearchIndex = [{"l":":ffmpeg-kit-android-lib","url":"index.html"}]
+var moduleSearchIndex = [{"l":":ffmpeg-kit-lib-android-lib","url":"index.html"}]

--- a/docs/apple/html/annotated.html
+++ b/docs/apple/html/annotated.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/classes.html
+++ b/docs/apple/html/classes.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d0f/struct_output_filter.html
+++ b/docs/apple/html/d0/d0f/struct_output_filter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d19/_return_code_8h.html
+++ b/docs/apple/html/d0/d19/_return_code_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d19/_return_code_8h_source.html
+++ b/docs/apple/html/d0/d19/_return_code_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d5a/_session_8h.html
+++ b/docs/apple/html/d0/d5a/_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d5a/_session_8h_source.html
+++ b/docs/apple/html/d0/d5a/_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d61/_atomic_long_8m.html
+++ b/docs/apple/html/d0/d61/_atomic_long_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d61/_atomic_long_8m_source.html
+++ b/docs/apple/html/d0/d61/_atomic_long_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d78/interface_media_information_session.html
+++ b/docs/apple/html/d0/d78/interface_media_information_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d7b/_atomic_long_8h.html
+++ b/docs/apple/html/d0/d7b/_atomic_long_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d0/d7b/_atomic_long_8h_source.html
+++ b/docs/apple/html/d0/d7b/_atomic_long_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d1/d9f/fftools__fopen__utf8_8h.html
+++ b/docs/apple/html/d1/d9f/fftools__fopen__utf8_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d1/d9f/fftools__fopen__utf8_8h_source.html
+++ b/docs/apple/html/d1/d9f/fftools__fopen__utf8_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -94,9 +94,9 @@ $(function() {
 <div class="line"><a id="l00019" name="l00019"></a><span class="lineno">   19</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment"> * This file is the modified version of fopen_utf8.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> */</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span> </div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="preprocessor">#ifndef FFTOOLS_FOPEN_UTF8_H</span></div>

--- a/docs/apple/html/d1/da2/struct_writer_context.html
+++ b/docs/apple/html/d1/da2/struct_writer_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d1/dba/fftools__ffmpeg__hw_8c.html
+++ b/docs/apple/html/d1/dba/fftools__ffmpeg__hw_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d1/dba/fftools__ffmpeg__hw_8c_source.html
+++ b/docs/apple/html/d1/dba/fftools__ffmpeg__hw_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,15 +97,15 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_hw.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 12.2019</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d2/d0b/interface_f_fmpeg_kit.html
+++ b/docs/apple/html/d2/d0b/interface_f_fmpeg_kit.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d1c/interface_log.html
+++ b/docs/apple/html/d2/d1c/interface_log.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d36/fftools__ffmpeg__filter_8c.html
+++ b/docs/apple/html/d2/d36/fftools__ffmpeg__filter_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d36/fftools__ffmpeg__filter_8c_source.html
+++ b/docs/apple/html/d2/d36/fftools__ffmpeg__filter_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,15 +98,15 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of ffmpeg_filter.c file living in ffmpeg source code under the fftools folder.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * We manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * 08.2018</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d2/d4b/_level_8h.html
+++ b/docs/apple/html/d2/d4b/_level_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d4b/_level_8h_source.html
+++ b/docs/apple/html/d2/d4b/_level_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d50/fftools__opt__common_8h.html
+++ b/docs/apple/html/d2/d50/fftools__opt__common_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d50/fftools__opt__common_8h_source.html
+++ b/docs/apple/html/d2/d50/fftools__opt__common_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of opt_common.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d2/d81/protocol_session-p.html
+++ b/docs/apple/html/d2/d81/protocol_session-p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/d94/struct_sync_queue_stream.html
+++ b/docs/apple/html/d2/d94/struct_sync_queue_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/ddd/struct_compact_context.html
+++ b/docs/apple/html/d2/ddd/struct_compact_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/def/_f_fmpeg_session_8h.html
+++ b/docs/apple/html/d2/def/_f_fmpeg_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d2/def/_f_fmpeg_session_8h_source.html
+++ b/docs/apple/html/d2/def/_f_fmpeg_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/d1d/_return_code_8m.html
+++ b/docs/apple/html/d3/d1d/_return_code_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/d1d/_return_code_8m_source.html
+++ b/docs/apple/html/d3/d1d/_return_code_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/d1d/struct_option.html
+++ b/docs/apple/html/d3/d1d/struct_option.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/d35/_media_information_json_parser_8m.html
+++ b/docs/apple/html/d3/d35/_media_information_json_parser_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/d35/_media_information_json_parser_8m_source.html
+++ b/docs/apple/html/d3/d35/_media_information_json_parser_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/d6e/struct_input_stream.html
+++ b/docs/apple/html/d3/d6e/struct_input_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/da2/struct_keyframe_force_ctx.html
+++ b/docs/apple/html/d3/da2/struct_keyframe_force_ctx.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/dad/ffmpegkit__exception_8h.html
+++ b/docs/apple/html/d3/dad/ffmpegkit__exception_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/dad/ffmpegkit__exception_8h_source.html
+++ b/docs/apple/html/d3/dad/ffmpegkit__exception_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d3/db7/struct_flat_context.html
+++ b/docs/apple/html/d3/db7/struct_flat_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/d53/_f_fmpeg_kit_8m.html
+++ b/docs/apple/html/d4/d53/_f_fmpeg_kit_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/d53/_f_fmpeg_kit_8m_source.html
+++ b/docs/apple/html/d4/d53/_f_fmpeg_kit_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -102,11 +102,11 @@ $(function() {
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="keyword">@implementation </span><a class="code hl_class" href="../../d2/d0b/interface_f_fmpeg_kit.html">FFmpegKit</a></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span> </div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span>+ (void)<a class="code hl_function" href="../../d2/d0b/interface_f_fmpeg_kit.html#a173faa92dd9452160cbff53243f17ba2">initialize</a> {</div>
-<div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span>    NSLog(<span class="stringliteral">@&quot;Loading ffmpeg-kit.\n&quot;</span>);</div>
+<div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span>    NSLog(<span class="stringliteral">@&quot;Loading ffmpeg-kit-lib.\n&quot;</span>);</div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span> </div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span>    [<a class="code hl_class" href="../../de/d5f/interface_f_fmpeg_kit_config.html">FFmpegKitConfig</a> class];</div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span> </div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span>    NSLog(<span class="stringliteral">@&quot;Loaded ffmpeg-kit-%@-%@-%@-%@.\n&quot;</span>, [<a class="code hl_class" href="../../df/d23/interface_packages.html">Packages</a> getPackageName], [<a class="code hl_class" href="../../dd/d2b/interface_arch_detect.html">ArchDetect</a> getArch], [<a class="code hl_class" href="../../de/d5f/interface_f_fmpeg_kit_config.html">FFmpegKitConfig</a> getVersion], [<a class="code hl_class" href="../../de/d5f/interface_f_fmpeg_kit_config.html">FFmpegKitConfig</a> getBuildDate]);</div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span>    NSLog(<span class="stringliteral">@&quot;Loaded ffmpeg-kit-lib-%@-%@-%@-%@.\n&quot;</span>, [<a class="code hl_class" href="../../df/d23/interface_packages.html">Packages</a> getPackageName], [<a class="code hl_class" href="../../dd/d2b/interface_arch_detect.html">ArchDetect</a> getArch], [<a class="code hl_class" href="../../de/d5f/interface_f_fmpeg_kit_config.html">FFmpegKitConfig</a> getVersion], [<a class="code hl_class" href="../../de/d5f/interface_f_fmpeg_kit_config.html">FFmpegKitConfig</a> getBuildDate]);</div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span>}</div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span> </div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span>+ (<a class="code hl_class" href="../../da/daf/interface_f_fmpeg_session.html">FFmpegSession</a>*)executeWithArguments:(NSArray*)arguments {</div>

--- a/docs/apple/html/d4/d5c/interface_media_information_json_parser.html
+++ b/docs/apple/html/d4/d5c/interface_media_information_json_parser.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/d62/struct_obj_pool.html
+++ b/docs/apple/html/d4/d62/struct_obj_pool.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/da0/struct_default_context.html
+++ b/docs/apple/html/d4/da0/struct_default_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/dad/_f_fprobe_kit_8h.html
+++ b/docs/apple/html/d4/dad/_f_fprobe_kit_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/dad/_f_fprobe_kit_8h_source.html
+++ b/docs/apple/html/d4/dad/_f_fprobe_kit_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/daf/_log_callback_8h.html
+++ b/docs/apple/html/d4/daf/_log_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/daf/_log_callback_8h_source.html
+++ b/docs/apple/html/d4/daf/_log_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/de8/interface_chapter.html
+++ b/docs/apple/html/d4/de8/interface_chapter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/df4/_stream_information_8h.html
+++ b/docs/apple/html/d4/df4/_stream_information_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/df4/_stream_information_8h_source.html
+++ b/docs/apple/html/d4/df4/_stream_information_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d4/dfd/struct_input_stream_1_1sub2video.html
+++ b/docs/apple/html/d4/dfd/struct_input_stream_1_1sub2video.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d14/_f_fprobe_session_complete_callback_8h.html
+++ b/docs/apple/html/d5/d14/_f_fprobe_session_complete_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d14/_f_fprobe_session_complete_callback_8h_source.html
+++ b/docs/apple/html/d5/d14/_f_fprobe_session_complete_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d19/struct_v_t_context.html
+++ b/docs/apple/html/d5/d19/struct_v_t_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/apple/html/d5/d1a/_media_information_8m.html
+++ b/docs/apple/html/d5/d1a/_media_information_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d1a/_media_information_8m_source.html
+++ b/docs/apple/html/d5/d1a/_media_information_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d5f/_packages_8h.html
+++ b/docs/apple/html/d5/d5f/_packages_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d5f/_packages_8h_source.html
+++ b/docs/apple/html/d5/d5f/_packages_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d78/_log_8m.html
+++ b/docs/apple/html/d5/d78/_log_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d78/_log_8m_source.html
+++ b/docs/apple/html/d5/d78/_log_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d8e/struct_benchmark_time_stamps.html
+++ b/docs/apple/html/d5/d8e/struct_benchmark_time_stamps.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d94/fftools__ffmpeg__mux_8c.html
+++ b/docs/apple/html/d5/d94/fftools__ffmpeg__mux_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/d94/fftools__ffmpeg__mux_8c_source.html
+++ b/docs/apple/html/d5/d94/fftools__ffmpeg__mux_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg_mux.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -107,7 +107,7 @@ $(function() {
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - want_sdp marked as thread-local</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - ms_from_ost migrated from ffmpeg_mux.c and marked as non-static</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d5/df5/fftools__objpool_8h.html
+++ b/docs/apple/html/d5/df5/fftools__objpool_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d5/df5/fftools__objpool_8h_source.html
+++ b/docs/apple/html/d5/df5/fftools__objpool_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of objpool.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d6/d16/struct_mux_stream.html
+++ b/docs/apple/html/d6/d16/struct_mux_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d2c/struct_audio_channel_map.html
+++ b/docs/apple/html/d6/d2c/struct_audio_channel_map.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d35/fftools__sync__queue_8h.html
+++ b/docs/apple/html/d6/d35/fftools__sync__queue_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d35/fftools__sync__queue_8h_source.html
+++ b/docs/apple/html/d6/d35/fftools__sync__queue_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of sync_queue.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d6/d36/interface_f_fprobe_kit.html
+++ b/docs/apple/html/d6/d36/interface_f_fprobe_kit.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d42/_log_redirection_strategy_8h.html
+++ b/docs/apple/html/d6/d42/_log_redirection_strategy_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d42/_log_redirection_strategy_8h_source.html
+++ b/docs/apple/html/d6/d42/_log_redirection_strategy_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d47/_f_fmpeg_session_complete_callback_8h.html
+++ b/docs/apple/html/d6/d47/_f_fmpeg_session_complete_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d47/_f_fmpeg_session_complete_callback_8h_source.html
+++ b/docs/apple/html/d6/d47/_f_fmpeg_session_complete_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d53/struct_j_s_o_n_context.html
+++ b/docs/apple/html/d6/d53/struct_j_s_o_n_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d69/struct_option_group.html
+++ b/docs/apple/html/d6/d69/struct_option_group.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d6e/_f_fmpeg_session_8m.html
+++ b/docs/apple/html/d6/d6e/_f_fmpeg_session_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d6e/_f_fmpeg_session_8m_source.html
+++ b/docs/apple/html/d6/d6e/_f_fmpeg_session_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d8f/_arch_detect_8h.html
+++ b/docs/apple/html/d6/d8f/_arch_detect_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/d8f/_arch_detect_8h_source.html
+++ b/docs/apple/html/d6/d8f/_arch_detect_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/dca/interface_media_information.html
+++ b/docs/apple/html/d6/dca/interface_media_information.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/df1/_statistics_callback_8h.html
+++ b/docs/apple/html/d6/df1/_statistics_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/df1/_statistics_callback_8h_source.html
+++ b/docs/apple/html/d6/df1/_statistics_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d6/dff/struct_writer.html
+++ b/docs/apple/html/d6/dff/struct_writer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d0c/struct_input_filter.html
+++ b/docs/apple/html/d7/d0c/struct_input_filter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d3a/_media_information_json_parser_8h.html
+++ b/docs/apple/html/d7/d3a/_media_information_json_parser_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d3a/_media_information_json_parser_8h_source.html
+++ b/docs/apple/html/d7/d3a/_media_information_json_parser_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d48/fftools__ffmpeg_8c.html
+++ b/docs/apple/html/d7/d48/fftools__ffmpeg_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d48/fftools__ffmpeg_8c_source.html
+++ b/docs/apple/html/d7/d48/fftools__ffmpeg_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,9 +98,9 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * This file is the modified version of ffmpeg.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -110,7 +110,7 @@ $(function() {
 <div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * - forward_report method signature updated</span></div>
 <div class="line"><a id="l00041" name="l00041"></a><span class="lineno">   41</span><span class="comment"> * - time field in report_callback/forward_report/set_report_callback updated as double</span></div>
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00044" name="l00044"></a><span class="lineno">   44</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00045" name="l00045"></a><span class="lineno">   45</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00046" name="l00046"></a><span class="lineno">   46</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d7/d4f/struct_option_group_list.html
+++ b/docs/apple/html/d7/d4f/struct_option_group_list.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d60/struct_frame_data.html
+++ b/docs/apple/html/d7/d60/struct_frame_data.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d96/_abstract_session_8m.html
+++ b/docs/apple/html/d7/d96/_abstract_session_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/d96/_abstract_session_8m_source.html
+++ b/docs/apple/html/d7/d96/_abstract_session_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/da5/_stream_information_8m.html
+++ b/docs/apple/html/d7/da5/_stream_information_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/da5/_stream_information_8m_source.html
+++ b/docs/apple/html/d7/da5/_stream_information_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/db2/struct_x_m_l_context.html
+++ b/docs/apple/html/d7/db2/struct_x_m_l_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/db3/fftools__ffmpeg_8h.html
+++ b/docs/apple/html/d7/db3/fftools__ffmpeg_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/db3/fftools__ffmpeg_8h_source.html
+++ b/docs/apple/html/d7/db3/fftools__ffmpeg_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -108,7 +108,7 @@ $(function() {
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - &quot;class&quot; member field renamed as clazz</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * - time field in set_report_callback updated as double</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d7/dc9/struct_demuxer.html
+++ b/docs/apple/html/d7/dc9/struct_demuxer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/dcc/fftools__cmdutils_8c.html
+++ b/docs/apple/html/d7/dcc/fftools__cmdutils_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/dcc/fftools__cmdutils_8c_source.html
+++ b/docs/apple/html/d7/dcc/fftools__cmdutils_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -99,15 +99,15 @@ $(function() {
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * This file is the modified version of cmdutils.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d7/dd8/fftools__objpool_8c.html
+++ b/docs/apple/html/d7/dd8/fftools__objpool_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d7/dd8/fftools__objpool_8c_source.html
+++ b/docs/apple/html/d7/dd8/fftools__objpool_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of objpool.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d8/d27/interface_callback_data.html
+++ b/docs/apple/html/d8/d27/interface_callback_data.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/d4e/fftools__cmdutils_8h.html
+++ b/docs/apple/html/d8/d4e/fftools__cmdutils_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/d4e/fftools__cmdutils_8h_source.html
+++ b/docs/apple/html/d8/d4e/fftools__cmdutils_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -99,15 +99,15 @@ $(function() {
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * This file is the modified version of cmdutils.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d8/d59/fftools__ffmpeg__mux__init_8c.html
+++ b/docs/apple/html/d8/d59/fftools__ffmpeg__mux__init_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/d59/fftools__ffmpeg__mux__init_8c_source.html
+++ b/docs/apple/html/d8/d59/fftools__ffmpeg__mux__init_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_mux_init.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d8/d78/_media_information_8h.html
+++ b/docs/apple/html/d8/d78/_media_information_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/d78/_media_information_8h_source.html
+++ b/docs/apple/html/d8/d78/_media_information_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/d78/fftools__ffprobe_8c.html
+++ b/docs/apple/html/d8/d78/fftools__ffprobe_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/d78/fftools__ffprobe_8c_source.html
+++ b/docs/apple/html/d8/d78/fftools__ffprobe_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,16 +98,16 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * This file is the modified version of ffprobe.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * - fftools header names updated</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00041" name="l00041"></a><span class="lineno">   41</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d8/d99/struct_input_file.html
+++ b/docs/apple/html/d8/d99/struct_input_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d8/dee/struct_read_interval.html
+++ b/docs/apple/html/d8/dee/struct_read_interval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d0a/_f_fprobe_session_8m.html
+++ b/docs/apple/html/d9/d0a/_f_fprobe_session_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d0a/_f_fprobe_session_8m_source.html
+++ b/docs/apple/html/d9/d0a/_f_fprobe_session_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d11/structsection.html
+++ b/docs/apple/html/d9/d11/structsection.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d28/fftools__ffmpeg__demux_8c.html
+++ b/docs/apple/html/d9/d28/fftools__ffmpeg__demux_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d28/fftools__ffmpeg__demux_8c_source.html
+++ b/docs/apple/html/d9/d28/fftools__ffmpeg__demux_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg_demux.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/d9/d28/struct_sync_queue.html
+++ b/docs/apple/html/d9/d28/struct_sync_queue.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d6c/struct_demux_msg.html
+++ b/docs/apple/html/d9/d6c/struct_demux_msg.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d6d/structunit__value.html
+++ b/docs/apple/html/d9/d6d/structunit__value.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d76/_abstract_session_8h.html
+++ b/docs/apple/html/d9/d76/_abstract_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/d76/_abstract_session_8h_source.html
+++ b/docs/apple/html/d9/d76/_abstract_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/da3/_chapter_8m.html
+++ b/docs/apple/html/d9/da3/_chapter_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/da3/_chapter_8m_source.html
+++ b/docs/apple/html/d9/da3/_chapter_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/db1/_statistics_8m.html
+++ b/docs/apple/html/d9/db1/_statistics_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/db1/_statistics_8m_source.html
+++ b/docs/apple/html/d9/db1/_statistics_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/db4/struct_thread_queue.html
+++ b/docs/apple/html/d9/db4/struct_thread_queue.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/db7/fftools__ffmpeg__videotoolbox_8c.html
+++ b/docs/apple/html/d9/db7/fftools__ffmpeg__videotoolbox_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/apple/html/d9/db7/fftools__ffmpeg__videotoolbox_8c_source.html
+++ b/docs/apple/html/d9/db7/fftools__ffmpeg__videotoolbox_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/apple/html/d9/dcc/interface_statistics.html
+++ b/docs/apple/html/d9/dcc/interface_statistics.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/d9/de7/struct_filter_graph.html
+++ b/docs/apple/html/d9/de7/struct_filter_graph.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d2c/fftools__opt__common_8c.html
+++ b/docs/apple/html/da/d2c/fftools__opt__common_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d2c/fftools__opt__common_8c_source.html
+++ b/docs/apple/html/da/d2c/fftools__opt__common_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,15 +98,15 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of opt_common.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - time field in report_callback updated as double</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/da/d4f/struct_i_n_i_context.html
+++ b/docs/apple/html/da/d4f/struct_i_n_i_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d56/struct_enc_stats_file.html
+++ b/docs/apple/html/da/d56/struct_enc_stats_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d62/struct_fifo_elem.html
+++ b/docs/apple/html/da/d62/struct_fifo_elem.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d66/fftools__ffmpeg__opt_8c.html
+++ b/docs/apple/html/da/d66/fftools__ffmpeg__opt_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d66/fftools__ffmpeg__opt_8c_source.html
+++ b/docs/apple/html/da/d66/fftools__ffmpeg__opt_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,9 +98,9 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of ffmpeg_opt.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -108,7 +108,7 @@ $(function() {
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - include fftools_ffmpeg_mux.h added</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * - fftools header names updated</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * 08.2020</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/da/d87/fftools__thread__queue_8h.html
+++ b/docs/apple/html/da/d87/fftools__thread__queue_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/d87/fftools__thread__queue_8h_source.html
+++ b/docs/apple/html/da/d87/fftools__thread__queue_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of thread_queue.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/da/d9e/_f_fmpeg_kit_config_8m.html
+++ b/docs/apple/html/da/d9e/_f_fmpeg_kit_config_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -1337,7 +1337,7 @@ Variables</h2></td></tr>
         </tr>
       </table>
 </div><div class="memdoc">
-<p>Prefix of named pipes created by ffmpeg-kit. </p>
+<p>Prefix of named pipes created by ffmpeg-kit-lib. </p>
 
 <p class="definition">Definition at line <a class="el" href="../../da/d9e/_f_fmpeg_kit_config_8m_source.html#l00044">44</a> of file <a class="el" href="../../da/d9e/_f_fmpeg_kit_config_8m_source.html">FFmpegKitConfig.m</a>.</p>
 

--- a/docs/apple/html/da/d9e/_f_fmpeg_kit_config_8m_source.html
+++ b/docs/apple/html/da/d9e/_f_fmpeg_kit_config_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/daf/interface_f_fmpeg_session.html
+++ b/docs/apple/html/da/daf/interface_f_fmpeg_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/df2/_statistics_8h.html
+++ b/docs/apple/html/da/df2/_statistics_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/df2/_statistics_8h_source.html
+++ b/docs/apple/html/da/df2/_statistics_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/df4/_log_8h.html
+++ b/docs/apple/html/da/df4/_log_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/df4/_log_8h_source.html
+++ b/docs/apple/html/da/df4/_log_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/df5/_packages_8m.html
+++ b/docs/apple/html/da/df5/_packages_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/da/df5/_packages_8m_source.html
+++ b/docs/apple/html/da/df5/_packages_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/d35/_arch_detect_8m.html
+++ b/docs/apple/html/db/d35/_arch_detect_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/d35/_arch_detect_8m_source.html
+++ b/docs/apple/html/db/d35/_arch_detect_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/d60/struct_stream_map.html
+++ b/docs/apple/html/db/d60/struct_stream_map.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/d76/interface_return_code.html
+++ b/docs/apple/html/db/d76/interface_return_code.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/d7d/interface_atomic_long.html
+++ b/docs/apple/html/db/d7d/interface_atomic_long.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/db5/struct_option_parse_context.html
+++ b/docs/apple/html/db/db5/struct_option_parse_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/dbb/struct_enc_stats.html
+++ b/docs/apple/html/db/dbb/struct_enc_stats.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/dd7/struct_option_group_def.html
+++ b/docs/apple/html/db/dd7/struct_option_group_def.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/dde/struct_output_stream.html
+++ b/docs/apple/html/db/dde/struct_output_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/db/de2/interface_abstract_session.html
+++ b/docs/apple/html/db/de2/interface_abstract_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/d16/struct_last_frame_duration.html
+++ b/docs/apple/html/dc/d16/struct_last_frame_duration.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/d1e/struct_option_def.html
+++ b/docs/apple/html/dc/d1e/struct_option_def.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/d56/fftools__thread__queue_8c.html
+++ b/docs/apple/html/dc/d56/fftools__thread__queue_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/d56/fftools__thread__queue_8c_source.html
+++ b/docs/apple/html/dc/d56/fftools__thread__queue_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of thread_queue.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/dc/d8d/_chapter_8h.html
+++ b/docs/apple/html/dc/d8d/_chapter_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/d8d/_chapter_8h_source.html
+++ b/docs/apple/html/dc/d8d/_chapter_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/da0/_f_fprobe_session_8h.html
+++ b/docs/apple/html/dc/da0/_f_fprobe_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/da0/_f_fprobe_session_8h_source.html
+++ b/docs/apple/html/dc/da0/_f_fprobe_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dc/df8/union_sync_queue_frame.html
+++ b/docs/apple/html/dc/df8/union_sync_queue_frame.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d0c/struct_enc_stats_component.html
+++ b/docs/apple/html/dd/d0c/struct_enc_stats_component.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d15/interface_f_fprobe_session.html
+++ b/docs/apple/html/dd/d15/interface_f_fprobe_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d15/struct_log_buffer.html
+++ b/docs/apple/html/dd/d15/struct_log_buffer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d2b/interface_arch_detect.html
+++ b/docs/apple/html/dd/d2b/interface_arch_detect.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d69/_media_information_session_8h.html
+++ b/docs/apple/html/dd/d69/_media_information_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d69/_media_information_session_8h_source.html
+++ b/docs/apple/html/dd/d69/_media_information_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d91/_media_information_session_8m.html
+++ b/docs/apple/html/dd/d91/_media_information_session_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/d91/_media_information_session_8m_source.html
+++ b/docs/apple/html/dd/d91/_media_information_session_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/da5/struct_specifier_opt.html
+++ b/docs/apple/html/dd/da5/struct_specifier_opt.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/dd/ddc/interface_stream_information.html
+++ b/docs/apple/html/dd/ddc/interface_stream_information.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/d29/struct_muxer.html
+++ b/docs/apple/html/de/d29/struct_muxer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/d57/_execute_callback_8h.html
+++ b/docs/apple/html/de/d57/_execute_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/apple/html/de/d57/_execute_callback_8h_source.html
+++ b/docs/apple/html/de/d57/_execute_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/apple/html/de/d5f/interface_f_fmpeg_kit_config.html
+++ b/docs/apple/html/de/d5f/interface_f_fmpeg_kit_config.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/db1/ffmpegkit__exception_8m.html
+++ b/docs/apple/html/de/db1/ffmpegkit__exception_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/db1/ffmpegkit__exception_8m_source.html
+++ b/docs/apple/html/de/db1/ffmpegkit__exception_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/dc7/struct_h_w_device.html
+++ b/docs/apple/html/de/dc7/struct_h_w_device.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/dcd/_f_fprobe_kit_8m.html
+++ b/docs/apple/html/de/dcd/_f_fprobe_kit_8m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/dcd/_f_fprobe_kit_8m_source.html
+++ b/docs/apple/html/de/dcd/_f_fprobe_kit_8m_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/de/df2/struct_output_file.html
+++ b/docs/apple/html/de/df2/struct_output_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d13/_session_state_8h.html
+++ b/docs/apple/html/df/d13/_session_state_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d13/_session_state_8h_source.html
+++ b/docs/apple/html/df/d13/_session_state_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d23/interface_packages.html
+++ b/docs/apple/html/df/d23/interface_packages.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d2b/fftools__ffmpeg__mux_8h.html
+++ b/docs/apple/html/df/d2b/fftools__ffmpeg__mux_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d2b/fftools__ffmpeg__mux_8h_source.html
+++ b/docs/apple/html/df/d2b/fftools__ffmpeg__mux_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_mux.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/df/d37/struct_h_w_accel.html
+++ b/docs/apple/html/df/d37/struct_h_w_accel.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;4.5</span>
    </div>

--- a/docs/apple/html/df/d48/_f_fmpeg_kit_config_8h.html
+++ b/docs/apple/html/df/d48/_f_fmpeg_kit_config_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d48/_f_fmpeg_kit_config_8h_source.html
+++ b/docs/apple/html/df/d48/_f_fmpeg_kit_config_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d57/_media_information_session_complete_callback_8h.html
+++ b/docs/apple/html/df/d57/_media_information_session_complete_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d57/_media_information_session_complete_callback_8h_source.html
+++ b/docs/apple/html/df/d57/_media_information_session_complete_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d77/struct_options_context.html
+++ b/docs/apple/html/df/d77/struct_options_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d99/_f_fmpeg_kit_8h.html
+++ b/docs/apple/html/df/d99/_f_fmpeg_kit_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/d99/_f_fmpeg_kit_8h_source.html
+++ b/docs/apple/html/df/d99/_f_fmpeg_kit_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/dbb/fftools__sync__queue_8c.html
+++ b/docs/apple/html/df/dbb/fftools__sync__queue_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/df/dbb/fftools__sync__queue_8c_source.html
+++ b/docs/apple/html/df/dbb/fftools__sync__queue_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of sync_queue.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/apple/html/files.html
+++ b/docs/apple/html/files.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions.html
+++ b/docs/apple/html/functions.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_a.html
+++ b/docs/apple/html/functions_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API
    &#160;<span id="projectnumber">4.4</span>

--- a/docs/apple/html/functions_b.html
+++ b/docs/apple/html/functions_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_c.html
+++ b/docs/apple/html/functions_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_d.html
+++ b/docs/apple/html/functions_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_e.html
+++ b/docs/apple/html/functions_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_f.html
+++ b/docs/apple/html/functions_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func.html
+++ b/docs/apple/html/functions_func.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_a.html
+++ b/docs/apple/html/functions_func_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API
    &#160;<span id="projectnumber">4.4</span>

--- a/docs/apple/html/functions_func_c.html
+++ b/docs/apple/html/functions_func_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_d.html
+++ b/docs/apple/html/functions_func_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_e.html
+++ b/docs/apple/html/functions_func_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_f.html
+++ b/docs/apple/html/functions_func_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_g.html
+++ b/docs/apple/html/functions_func_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_i.html
+++ b/docs/apple/html/functions_func_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_l.html
+++ b/docs/apple/html/functions_func_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_m.html
+++ b/docs/apple/html/functions_func_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_p.html
+++ b/docs/apple/html/functions_func_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_r.html
+++ b/docs/apple/html/functions_func_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_s.html
+++ b/docs/apple/html/functions_func_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_t.html
+++ b/docs/apple/html/functions_func_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_func_w.html
+++ b/docs/apple/html/functions_func_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_g.html
+++ b/docs/apple/html/functions_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_h.html
+++ b/docs/apple/html/functions_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_i.html
+++ b/docs/apple/html/functions_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_k.html
+++ b/docs/apple/html/functions_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_l.html
+++ b/docs/apple/html/functions_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_m.html
+++ b/docs/apple/html/functions_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_n.html
+++ b/docs/apple/html/functions_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_o.html
+++ b/docs/apple/html/functions_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_p.html
+++ b/docs/apple/html/functions_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_q.html
+++ b/docs/apple/html/functions_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_r.html
+++ b/docs/apple/html/functions_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_s.html
+++ b/docs/apple/html/functions_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_t.html
+++ b/docs/apple/html/functions_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_u.html
+++ b/docs/apple/html/functions_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_v.html
+++ b/docs/apple/html/functions_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars.html
+++ b/docs/apple/html/functions_vars.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_b.html
+++ b/docs/apple/html/functions_vars_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_c.html
+++ b/docs/apple/html/functions_vars_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_d.html
+++ b/docs/apple/html/functions_vars_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_e.html
+++ b/docs/apple/html/functions_vars_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_f.html
+++ b/docs/apple/html/functions_vars_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_g.html
+++ b/docs/apple/html/functions_vars_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_h.html
+++ b/docs/apple/html/functions_vars_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_i.html
+++ b/docs/apple/html/functions_vars_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_k.html
+++ b/docs/apple/html/functions_vars_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_l.html
+++ b/docs/apple/html/functions_vars_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_m.html
+++ b/docs/apple/html/functions_vars_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_n.html
+++ b/docs/apple/html/functions_vars_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_o.html
+++ b/docs/apple/html/functions_vars_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_p.html
+++ b/docs/apple/html/functions_vars_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_q.html
+++ b/docs/apple/html/functions_vars_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_r.html
+++ b/docs/apple/html/functions_vars_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_s.html
+++ b/docs/apple/html/functions_vars_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_t.html
+++ b/docs/apple/html/functions_vars_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_u.html
+++ b/docs/apple/html/functions_vars_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_v.html
+++ b/docs/apple/html/functions_vars_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_w.html
+++ b/docs/apple/html/functions_vars_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_vars_x.html
+++ b/docs/apple/html/functions_vars_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_w.html
+++ b/docs/apple/html/functions_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/functions_x.html
+++ b/docs/apple/html/functions_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals.html
+++ b/docs/apple/html/globals.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_a.html
+++ b/docs/apple/html/globals_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_b.html
+++ b/docs/apple/html/globals_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_c.html
+++ b/docs/apple/html/globals_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_d.html
+++ b/docs/apple/html/globals_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_defs.html
+++ b/docs/apple/html/globals_defs.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_e.html
+++ b/docs/apple/html/globals_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_enum.html
+++ b/docs/apple/html/globals_enum.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_eval.html
+++ b/docs/apple/html/globals_eval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_f.html
+++ b/docs/apple/html/globals_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func.html
+++ b/docs/apple/html/globals_func.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_b.html
+++ b/docs/apple/html/globals_func_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_c.html
+++ b/docs/apple/html/globals_func_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_d.html
+++ b/docs/apple/html/globals_func_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_e.html
+++ b/docs/apple/html/globals_func_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_f.html
+++ b/docs/apple/html/globals_func_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_g.html
+++ b/docs/apple/html/globals_func_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_h.html
+++ b/docs/apple/html/globals_func_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_i.html
+++ b/docs/apple/html/globals_func_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_j.html
+++ b/docs/apple/html/globals_func_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_l.html
+++ b/docs/apple/html/globals_func_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_m.html
+++ b/docs/apple/html/globals_func_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_n.html
+++ b/docs/apple/html/globals_func_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_o.html
+++ b/docs/apple/html/globals_func_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_p.html
+++ b/docs/apple/html/globals_func_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_q.html
+++ b/docs/apple/html/globals_func_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_r.html
+++ b/docs/apple/html/globals_func_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_s.html
+++ b/docs/apple/html/globals_func_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_t.html
+++ b/docs/apple/html/globals_func_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_u.html
+++ b/docs/apple/html/globals_func_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_v.html
+++ b/docs/apple/html/globals_func_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_w.html
+++ b/docs/apple/html/globals_func_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_func_x.html
+++ b/docs/apple/html/globals_func_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_g.html
+++ b/docs/apple/html/globals_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_h.html
+++ b/docs/apple/html/globals_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_i.html
+++ b/docs/apple/html/globals_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_j.html
+++ b/docs/apple/html/globals_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_k.html
+++ b/docs/apple/html/globals_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_l.html
+++ b/docs/apple/html/globals_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_m.html
+++ b/docs/apple/html/globals_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_n.html
+++ b/docs/apple/html/globals_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_o.html
+++ b/docs/apple/html/globals_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_p.html
+++ b/docs/apple/html/globals_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_q.html
+++ b/docs/apple/html/globals_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_r.html
+++ b/docs/apple/html/globals_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_s.html
+++ b/docs/apple/html/globals_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_t.html
+++ b/docs/apple/html/globals_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_type.html
+++ b/docs/apple/html/globals_type.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_u.html
+++ b/docs/apple/html/globals_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_v.html
+++ b/docs/apple/html/globals_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars.html
+++ b/docs/apple/html/globals_vars.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_a.html
+++ b/docs/apple/html/globals_vars_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_b.html
+++ b/docs/apple/html/globals_vars_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_c.html
+++ b/docs/apple/html/globals_vars_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_d.html
+++ b/docs/apple/html/globals_vars_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_e.html
+++ b/docs/apple/html/globals_vars_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_f.html
+++ b/docs/apple/html/globals_vars_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_g.html
+++ b/docs/apple/html/globals_vars_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_h.html
+++ b/docs/apple/html/globals_vars_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_i.html
+++ b/docs/apple/html/globals_vars_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_j.html
+++ b/docs/apple/html/globals_vars_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_k.html
+++ b/docs/apple/html/globals_vars_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_l.html
+++ b/docs/apple/html/globals_vars_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_m.html
+++ b/docs/apple/html/globals_vars_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_n.html
+++ b/docs/apple/html/globals_vars_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_o.html
+++ b/docs/apple/html/globals_vars_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_p.html
+++ b/docs/apple/html/globals_vars_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_q.html
+++ b/docs/apple/html/globals_vars_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_r.html
+++ b/docs/apple/html/globals_vars_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_s.html
+++ b/docs/apple/html/globals_vars_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_t.html
+++ b/docs/apple/html/globals_vars_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_u.html
+++ b/docs/apple/html/globals_vars_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_v.html
+++ b/docs/apple/html/globals_vars_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_w.html
+++ b/docs/apple/html/globals_vars_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_vars_x.html
+++ b/docs/apple/html/globals_vars_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_w.html
+++ b/docs/apple/html/globals_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/globals_x.html
+++ b/docs/apple/html/globals_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/hierarchy.html
+++ b/docs/apple/html/hierarchy.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/apple/html/index.html
+++ b/docs/apple/html/index.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit iOS / macOS / tvOS API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # FFmpegKit
 
 ## Notice
-FFmpegKit has been officially retired. There will be no further `ffmpeg-kit` releases. All previously released `ffmpeg-kit` binaries will be removed according to the following schedule. Thank you for your support and interest in this project.
+FFmpegKit has been officially retired. There will be no further `ffmpeg-kit-lib` releases. All previously released `ffmpeg-kit-lib` binaries will be removed according to the following schedule. Thank you for your support and interest in this project.
 
 Thank you for your support and contributions over the course of this project.
 
@@ -10,12 +10,12 @@ Thank you for your support and contributions over the course of this project.
 |   Less than 6.0   | February 1st, 2025 |
 |        6.0        |  April 1st, 2025   |
 
-<img src="https://github.com/arthenica/ffmpeg-kit/raw/main/docs/assets/ffmpeg-kit-icon-v9.png" width="180">
+<img src="https://github.com/arthenica/ffmpeg-kit-lib/raw/main/docs/assets/ffmpeg-kit-lib-icon-v9.png" width="180">
 
 `FFmpegKit` is a collection of tools to use `FFmpeg` in `Android`, `iOS`, `Linux`, `macOS`, `tvOS`, `Flutter` and `React Native` applications.
 
 It includes scripts to build `FFmpeg` native libraries, a wrapper library to run `FFmpeg`/`FFprobe` commands in
-applications and 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit/releases),
+applications and 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit-lib/releases),
 [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and [npm](https://www.npmjs.com).
 
 ### 1. Features
@@ -24,32 +24,32 @@ applications and 8 prebuilt binary packages available at [Github](https://github
 - Supports native platforms: Android, iOS, Linux, macOS and tvOS
 - Supports hybrid platforms: Flutter, React Native
 - Based on FFmpeg `v4.5-dev` or later with optional system and external libraries
-- 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit/releases), [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and [npm](https://www.npmjs.com)
+- 8 prebuilt binary packages available at [Github](https://github.com/arthenica/ffmpeg-kit-lib/releases), [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and [npm](https://www.npmjs.com)
 - Licensed under `LGPL 3.0` by default, some packages licensed by `GPL v3.0` effectively
 
 ### 2. Android
 
-See [Android](https://github.com/arthenica/ffmpeg-kit/tree/development/android) to learn more about `FFmpegKit` for
+See [Android](https://github.com/arthenica/ffmpeg-kit-lib/tree/development/android) to learn more about `FFmpegKit` for
 `Android`.
 
 ### 3. iOS, macOS, tvOS
 
-See [Apple](https://github.com/arthenica/ffmpeg-kit/tree/development/apple) to use `FFmpegKit` on `Apple` platforms
+See [Apple](https://github.com/arthenica/ffmpeg-kit-lib/tree/development/apple) to use `FFmpegKit` on `Apple` platforms
 (`iOS`, `macOS`, `tvOS`).
 
 ### 4. Flutter
 
-See [Flutter](https://github.com/arthenica/ffmpeg-kit/tree/main/flutter/flutter) to learn more about `FFmpegKit` for
+See [Flutter](https://github.com/arthenica/ffmpeg-kit-lib/tree/main/flutter/flutter) to learn more about `FFmpegKit` for
 `Flutter`.
 
 ### 5. Linux
 
-See [Linux](https://github.com/arthenica/ffmpeg-kit/tree/main/linux) to learn more about `FFmpegKit` for
+See [Linux](https://github.com/arthenica/ffmpeg-kit-lib/tree/main/linux) to learn more about `FFmpegKit` for
 `Linux`.
 
 ### 6. React Native
 
-See [React Native](https://github.com/arthenica/ffmpeg-kit/tree/main/react-native) to learn more about `FFmpegKit` for
+See [React Native](https://github.com/arthenica/ffmpeg-kit-lib/tree/main/react-native) to learn more about `FFmpegKit` for
 `React Native`.
 
 ### 7. Build Scripts
@@ -57,7 +57,7 @@ See [React Native](https://github.com/arthenica/ffmpeg-kit/tree/main/react-nativ
 Use `android.sh`, `ios.sh`, `linux.sh`, `macos.sh` and `tvos.sh` to build `FFmpegKit` for each native platform.
 
 All scripts support additional options to enable optional libraries and disable platform architectures. See
-[Building](https://github.com/arthenica/ffmpeg-kit/wiki/Building) wiki page for the details.
+[Building](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Building) wiki page for the details.
 
 ### 8. FFmpegKit Library
 
@@ -71,13 +71,13 @@ a `JavaScript` API with `Typescript` definitions, which are identical in terms o
 
 ### 9. Packages
 
-There are eight different `ffmpeg-kit` packages distributed on
-[Github](https://github.com/arthenica/ffmpeg-kit/releases),
+There are eight different `ffmpeg-kit-lib` packages distributed on
+[Github](https://github.com/arthenica/ffmpeg-kit-lib/releases),
 [Maven Central](https://search.maven.org), [CocoaPods](https://cocoapods.org), [pub](https://pub.dev) and
 [npm](https://www.npmjs.com).
 Below you can see which system libraries and external libraries are enabled in each one of them.
 
-Please remember that some parts of `FFmpeg` are licensed under the `GPL` and only `GPL` licensed `ffmpeg-kit` packages
+Please remember that some parts of `FFmpeg` are licensed under the `GPL` and only `GPL` licensed `ffmpeg-kit-lib` packages
 include them.
 
 <table>
@@ -124,26 +124,26 @@ the exact version number of `FFmpeg` is obtained using the `git describe --tags`
 
 |    Platforms     |                                  FFmpegKit Version                                  | FFmpeg Version | Release Date |
 |:----------------:|:-----------------------------------------------------------------------------------:|:--------------:|:------------:|
-|     Flutter      |   [6.0.3](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.3)    |      6.0       | Sep 19, 2023 |
-|   React Native   | [6.0.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.2) |      6.0       | Sep 19, 2023 |
-|     Flutter      |   [6.0.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.2)    |      6.0       | Sep 03, 2023 |
-|   React Native   | [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.1) |      6.0       | Sep 03, 2023  |
-|     Flutter      |   [6.0.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.1)    |      6.0       | Sep 03, 2023 |
-|   React Native   | [6.0.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v6.0.0) |      6.0       | Aug 27, 2023 |
-|     Flutter      |   [6.0.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v6.0.0)    |      6.0       | Aug 27, 2023 |
-|      Android<br>Apple       |         [6.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/v6.0)          |      6.0       | Aug 21, 2023 |
-|   React Native   | [5.1.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v5.1.0) |     5.1.2      | Oct 02, 2022 |
-|     Flutter      |   [5.1.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v5.1.0)    |     5.1.2      | Oct 02, 2022 |
-|     Android<br>Apple      |         [5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/v5.1)          |     5.1.2      | Sep 29, 2022 |
-|   React Native   | [4.5.2](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v4.5.2) |  4.5-dev-3393  | May 25, 2022 |
-|     Flutter      |   [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v4.5.1)    |  4.5-dev-3393  | Jan 02, 2022 |
-|   React Native   | [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v4.5.1) |  4.5-dev-3393  | Jan 02, 2022 |
-|     Android      |       [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.5.1)        |  4.5-dev-3393  | Jan 01, 2022 |
-|      Apple       |       [4.5.1](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.5.1)        |  4.5-dev-3393  | Dec 30, 2021 |
-|     Flutter      |   [4.5.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/flutter.v4.5.0)    |  4.5-dev-2008  | Oct 05, 2021 |
-|   React Native   | [4.5.0](https://github.com/arthenica/ffmpeg-kit/releases/tag/react.native.v4.5.0) |  4.5-dev-2008  | Oct 01, 2021 |
-| Android<br>Apple |         [4.5](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.5)          |  4.5-dev-2008  | Sep 18, 2021 |
-| Android<br>Apple |         [4.4](https://github.com/arthenica/ffmpeg-kit/releases/tag/v4.4)          |  4.4-dev-3015  | Mar 03, 2021 |
+|     Flutter      |   [6.0.3](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.3)    |      6.0       | Sep 19, 2023 |
+|   React Native   | [6.0.2](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v6.0.2) |      6.0       | Sep 19, 2023 |
+|     Flutter      |   [6.0.2](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.2)    |      6.0       | Sep 03, 2023 |
+|   React Native   | [6.0.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v6.0.1) |      6.0       | Sep 03, 2023  |
+|     Flutter      |   [6.0.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.1)    |      6.0       | Sep 03, 2023 |
+|   React Native   | [6.0.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v6.0.0) |      6.0       | Aug 27, 2023 |
+|     Flutter      |   [6.0.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v6.0.0)    |      6.0       | Aug 27, 2023 |
+|      Android<br>Apple       |         [6.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v6.0)          |      6.0       | Aug 21, 2023 |
+|   React Native   | [5.1.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v5.1.0) |     5.1.2      | Oct 02, 2022 |
+|     Flutter      |   [5.1.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v5.1.0)    |     5.1.2      | Oct 02, 2022 |
+|     Android<br>Apple      |         [5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v5.1)          |     5.1.2      | Sep 29, 2022 |
+|   React Native   | [4.5.2](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v4.5.2) |  4.5-dev-3393  | May 25, 2022 |
+|     Flutter      |   [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v4.5.1)    |  4.5-dev-3393  | Jan 02, 2022 |
+|   React Native   | [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v4.5.1) |  4.5-dev-3393  | Jan 02, 2022 |
+|     Android      |       [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.5.1)        |  4.5-dev-3393  | Jan 01, 2022 |
+|      Apple       |       [4.5.1](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.5.1)        |  4.5-dev-3393  | Dec 30, 2021 |
+|     Flutter      |   [4.5.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/flutter.v4.5.0)    |  4.5-dev-2008  | Oct 05, 2021 |
+|   React Native   | [4.5.0](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/react.native.v4.5.0) |  4.5-dev-2008  | Oct 01, 2021 |
+| Android<br>Apple |         [4.5](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.5)          |  4.5-dev-2008  | Sep 18, 2021 |
+| Android<br>Apple |         [4.4](https://github.com/arthenica/ffmpeg-kit-lib/releases/tag/v4.4)          |  4.4-dev-3015  | Mar 03, 2021 |
 
 ### 11. LTS Releases
 
@@ -177,12 +177,12 @@ This table shows the differences between two variants.
 
 ### 12. Documentation
 
-A more detailed documentation is available under [Wiki](https://github.com/arthenica/ffmpeg-kit/wiki).
+A more detailed documentation is available under [Wiki](https://github.com/arthenica/ffmpeg-kit-lib/wiki).
 
 ### 13. Test Applications
 
 You can see how `FFmpegKit` is used inside an application by running test applications created under
-[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.
 
 All applications are identical and supports command execution, video encoding, accessing https urls, encoding audio,
 burning subtitles, video stabilisation, pipe operations and concurrent command execution.
@@ -202,8 +202,8 @@ libraries. Thus, `FFmpeg` libraries created by `FFmpegKit` are licensed under th
 `--enable-gpl` is provided they become subject to `GPL v3.0`. That is how prebuilt binaries with `-gpl` postfix are
 compiled.
 
-Refer to [Licenses](https://github.com/arthenica/ffmpeg-kit/wiki/Licenses) to see the licenses of all libraries.
-[Trademark](https://github.com/arthenica/ffmpeg-kit/wiki/Trademark) lists the trademarks used in the `FFmpegKit`
+Refer to [Licenses](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Licenses) to see the licenses of all libraries.
+[Trademark](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Trademark) lists the trademarks used in the `FFmpegKit`
 documentation.
 
 ### 15. Patents
@@ -213,13 +213,13 @@ include algorithms which are subject to software patents. If you live in a count
 patentable then you'll probably need to pay royalty fees to patent holders. We are not lawyers though, so we recommend
 that you seek legal advice first. See [FFmpeg Patent Mini-FAQ](https://ffmpeg.org/legal.html).
 
-`openh264` clearly states that it uses patented algorithms. Therefore, if you build `ffmpeg-kit` with `openh264` and
+`openh264` clearly states that it uses patented algorithms. Therefore, if you build `ffmpeg-kit-lib` with `openh264` and
 distribute that library, then you are subject to pay MPEG LA licensing fees. Refer to
 [OpenH264 FAQ](https://www.openh264.org/faq.html) page for the details.
 
 ### 16. Contributing
 
-See our [CONTRIBUTING](https://github.com/arthenica/ffmpeg-kit/blob/main/CONTRIBUTING.md) guide.
+See our [CONTRIBUTING](https://github.com/arthenica/ffmpeg-kit-lib/blob/main/CONTRIBUTING.md) guide.
 
 ### 17. See Also
 

--- a/docs/linux/html/annotated.html
+++ b/docs/linux/html/annotated.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/classes.html
+++ b/docs/linux/html/classes.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/d0f/struct_output_filter.html
+++ b/docs/linux/html/d0/d0f/struct_output_filter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/d19/_return_code_8h.html
+++ b/docs/linux/html/d0/d19/_return_code_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/d19/_return_code_8h_source.html
+++ b/docs/linux/html/d0/d19/_return_code_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/d5a/_session_8h.html
+++ b/docs/linux/html/d0/d5a/_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/d5a/_session_8h_source.html
+++ b/docs/linux/html/d0/d5a/_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/da7/_log_8cpp.html
+++ b/docs/linux/html/d0/da7/_log_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/da7/_log_8cpp_source.html
+++ b/docs/linux/html/d0/da7/_log_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/dc3/_f_fprobe_kit_8cpp.html
+++ b/docs/linux/html/d0/dc3/_f_fprobe_kit_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/dc3/_f_fprobe_kit_8cpp_source.html
+++ b/docs/linux/html/d0/dc3/_f_fprobe_kit_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d0/de7/classffmpegkit_1_1_statistics.html
+++ b/docs/linux/html/d0/de7/classffmpegkit_1_1_statistics.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/d8a/_chapter_8cpp.html
+++ b/docs/linux/html/d1/d8a/_chapter_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/d8a/_chapter_8cpp_source.html
+++ b/docs/linux/html/d1/d8a/_chapter_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/d9f/fftools__fopen__utf8_8h.html
+++ b/docs/linux/html/d1/d9f/fftools__fopen__utf8_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/d9f/fftools__fopen__utf8_8h_source.html
+++ b/docs/linux/html/d1/d9f/fftools__fopen__utf8_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -94,9 +94,9 @@ $(function() {
 <div class="line"><a id="l00019" name="l00019"></a><span class="lineno">   19</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment"> * This file is the modified version of fopen_utf8.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> */</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span> </div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="preprocessor">#ifndef FFTOOLS_FOPEN_UTF8_H</span></div>

--- a/docs/linux/html/d1/da2/struct_writer_context.html
+++ b/docs/linux/html/d1/da2/struct_writer_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/dba/fftools__ffmpeg__hw_8c.html
+++ b/docs/linux/html/d1/dba/fftools__ffmpeg__hw_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/dba/fftools__ffmpeg__hw_8c_source.html
+++ b/docs/linux/html/d1/dba/fftools__ffmpeg__hw_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,15 +97,15 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_hw.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 12.2019</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d1/dbf/_media_information_json_parser_8cpp.html
+++ b/docs/linux/html/d1/dbf/_media_information_json_parser_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/dbf/_media_information_json_parser_8cpp_source.html
+++ b/docs/linux/html/d1/dbf/_media_information_json_parser_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/dc9/_media_information_8cpp.html
+++ b/docs/linux/html/d1/dc9/_media_information_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/dc9/_media_information_8cpp_source.html
+++ b/docs/linux/html/d1/dc9/_media_information_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d1/df7/classffmpegkit_1_1_arch_detect.html
+++ b/docs/linux/html/d1/df7/classffmpegkit_1_1_arch_detect.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d25/namespaceffmpegkit.html
+++ b/docs/linux/html/d2/d25/namespaceffmpegkit.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d36/fftools__ffmpeg__filter_8c.html
+++ b/docs/linux/html/d2/d36/fftools__ffmpeg__filter_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d36/fftools__ffmpeg__filter_8c_source.html
+++ b/docs/linux/html/d2/d36/fftools__ffmpeg__filter_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,15 +98,15 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of ffmpeg_filter.c file living in ffmpeg source code under the fftools folder.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * We manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * 08.2018</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d2/d41/classffmpegkit_1_1_abstract_session.html
+++ b/docs/linux/html/d2/d41/classffmpegkit_1_1_abstract_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d4b/_level_8h.html
+++ b/docs/linux/html/d2/d4b/_level_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d4b/_level_8h_source.html
+++ b/docs/linux/html/d2/d4b/_level_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d50/fftools__opt__common_8h.html
+++ b/docs/linux/html/d2/d50/fftools__opt__common_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/d50/fftools__opt__common_8h_source.html
+++ b/docs/linux/html/d2/d50/fftools__opt__common_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of opt_common.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d2/d94/struct_sync_queue_stream.html
+++ b/docs/linux/html/d2/d94/struct_sync_queue_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/ddd/struct_compact_context.html
+++ b/docs/linux/html/d2/ddd/struct_compact_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/dee/classffmpegkit_1_1_f_fmpeg_session.html
+++ b/docs/linux/html/d2/dee/classffmpegkit_1_1_f_fmpeg_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/def/_f_fmpeg_session_8h.html
+++ b/docs/linux/html/d2/def/_f_fmpeg_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d2/def/_f_fmpeg_session_8h_source.html
+++ b/docs/linux/html/d2/def/_f_fmpeg_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/d1d/struct_option.html
+++ b/docs/linux/html/d3/d1d/struct_option.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/d3f/_statistics_8cpp.html
+++ b/docs/linux/html/d3/d3f/_statistics_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/d3f/_statistics_8cpp_source.html
+++ b/docs/linux/html/d3/d3f/_statistics_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/d5d/_media_information_session_8cpp.html
+++ b/docs/linux/html/d3/d5d/_media_information_session_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/d5d/_media_information_session_8cpp_source.html
+++ b/docs/linux/html/d3/d5d/_media_information_session_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/d6e/struct_input_stream.html
+++ b/docs/linux/html/d3/d6e/struct_input_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/da2/struct_keyframe_force_ctx.html
+++ b/docs/linux/html/d3/da2/struct_keyframe_force_ctx.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/dad/ffmpegkit__exception_8h.html
+++ b/docs/linux/html/d3/dad/ffmpegkit__exception_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/dad/ffmpegkit__exception_8h_source.html
+++ b/docs/linux/html/d3/dad/ffmpegkit__exception_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d3/db7/struct_flat_context.html
+++ b/docs/linux/html/d3/db7/struct_flat_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/d62/struct_obj_pool.html
+++ b/docs/linux/html/d4/d62/struct_obj_pool.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/da0/struct_default_context.html
+++ b/docs/linux/html/d4/da0/struct_default_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/dad/_f_fprobe_kit_8h.html
+++ b/docs/linux/html/d4/dad/_f_fprobe_kit_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/dad/_f_fprobe_kit_8h_source.html
+++ b/docs/linux/html/d4/dad/_f_fprobe_kit_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/daf/_log_callback_8h.html
+++ b/docs/linux/html/d4/daf/_log_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/daf/_log_callback_8h_source.html
+++ b/docs/linux/html/d4/daf/_log_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/dcf/classffmpegkit_1_1_return_code.html
+++ b/docs/linux/html/d4/dcf/classffmpegkit_1_1_return_code.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/df4/_stream_information_8h.html
+++ b/docs/linux/html/d4/df4/_stream_information_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/df4/_stream_information_8h_source.html
+++ b/docs/linux/html/d4/df4/_stream_information_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d4/dfd/struct_input_stream_1_1sub2video.html
+++ b/docs/linux/html/d4/dfd/struct_input_stream_1_1sub2video.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d0e/classffmpegkit_1_1_session.html
+++ b/docs/linux/html/d5/d0e/classffmpegkit_1_1_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d14/_f_fprobe_session_complete_callback_8h.html
+++ b/docs/linux/html/d5/d14/_f_fprobe_session_complete_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d14/_f_fprobe_session_complete_callback_8h_source.html
+++ b/docs/linux/html/d5/d14/_f_fprobe_session_complete_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d18/class_callback_data.html
+++ b/docs/linux/html/d5/d18/class_callback_data.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d5f/_packages_8h.html
+++ b/docs/linux/html/d5/d5f/_packages_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d5f/_packages_8h_source.html
+++ b/docs/linux/html/d5/d5f/_packages_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d8e/struct_benchmark_time_stamps.html
+++ b/docs/linux/html/d5/d8e/struct_benchmark_time_stamps.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d94/fftools__ffmpeg__mux_8c.html
+++ b/docs/linux/html/d5/d94/fftools__ffmpeg__mux_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/d94/fftools__ffmpeg__mux_8c_source.html
+++ b/docs/linux/html/d5/d94/fftools__ffmpeg__mux_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg_mux.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -107,7 +107,7 @@ $(function() {
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - want_sdp marked as thread-local</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - ms_from_ost migrated from ffmpeg_mux.c and marked as non-static</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d5/dce/_signal_8h.html
+++ b/docs/linux/html/d5/dce/_signal_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/dce/_signal_8h_source.html
+++ b/docs/linux/html/d5/dce/_signal_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/df5/fftools__objpool_8h.html
+++ b/docs/linux/html/d5/df5/fftools__objpool_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d5/df5/fftools__objpool_8h_source.html
+++ b/docs/linux/html/d5/df5/fftools__objpool_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of objpool.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d6/d16/struct_mux_stream.html
+++ b/docs/linux/html/d6/d16/struct_mux_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d2c/struct_audio_channel_map.html
+++ b/docs/linux/html/d6/d2c/struct_audio_channel_map.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d35/fftools__sync__queue_8h.html
+++ b/docs/linux/html/d6/d35/fftools__sync__queue_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d35/fftools__sync__queue_8h_source.html
+++ b/docs/linux/html/d6/d35/fftools__sync__queue_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of sync_queue.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d6/d42/_log_redirection_strategy_8h.html
+++ b/docs/linux/html/d6/d42/_log_redirection_strategy_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d42/_log_redirection_strategy_8h_source.html
+++ b/docs/linux/html/d6/d42/_log_redirection_strategy_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d47/_f_fmpeg_session_complete_callback_8h.html
+++ b/docs/linux/html/d6/d47/_f_fmpeg_session_complete_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d47/_f_fmpeg_session_complete_callback_8h_source.html
+++ b/docs/linux/html/d6/d47/_f_fmpeg_session_complete_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d53/struct_j_s_o_n_context.html
+++ b/docs/linux/html/d6/d53/struct_j_s_o_n_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d69/struct_option_group.html
+++ b/docs/linux/html/d6/d69/struct_option_group.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d8f/_arch_detect_8h.html
+++ b/docs/linux/html/d6/d8f/_arch_detect_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/d8f/_arch_detect_8h_source.html
+++ b/docs/linux/html/d6/d8f/_arch_detect_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/df1/_statistics_callback_8h.html
+++ b/docs/linux/html/d6/df1/_statistics_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/df1/_statistics_callback_8h_source.html
+++ b/docs/linux/html/d6/df1/_statistics_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/df7/_packages_8cpp.html
+++ b/docs/linux/html/d6/df7/_packages_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/df7/_packages_8cpp_source.html
+++ b/docs/linux/html/d6/df7/_packages_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d6/dff/struct_writer.html
+++ b/docs/linux/html/d6/dff/struct_writer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d0c/struct_input_filter.html
+++ b/docs/linux/html/d7/d0c/struct_input_filter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d2d/_stream_information_8cpp.html
+++ b/docs/linux/html/d7/d2d/_stream_information_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d2d/_stream_information_8cpp_source.html
+++ b/docs/linux/html/d7/d2d/_stream_information_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d3a/_media_information_json_parser_8h.html
+++ b/docs/linux/html/d7/d3a/_media_information_json_parser_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d3a/_media_information_json_parser_8h_source.html
+++ b/docs/linux/html/d7/d3a/_media_information_json_parser_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d48/fftools__ffmpeg_8c.html
+++ b/docs/linux/html/d7/d48/fftools__ffmpeg_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d48/fftools__ffmpeg_8c_source.html
+++ b/docs/linux/html/d7/d48/fftools__ffmpeg_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,9 +98,9 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * This file is the modified version of ffmpeg.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -110,7 +110,7 @@ $(function() {
 <div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * - forward_report method signature updated</span></div>
 <div class="line"><a id="l00041" name="l00041"></a><span class="lineno">   41</span><span class="comment"> * - time field in report_callback/forward_report/set_report_callback updated as double</span></div>
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00044" name="l00044"></a><span class="lineno">   44</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00045" name="l00045"></a><span class="lineno">   45</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00046" name="l00046"></a><span class="lineno">   46</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d7/d4c/structffmpegkit_1_1_f_fprobe_session_1_1_public_f_fprobe_session.html
+++ b/docs/linux/html/d7/d4c/structffmpegkit_1_1_f_fprobe_session_1_1_public_f_fprobe_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Linux API
    &#160;<span id="projectnumber">4.5.1</span>

--- a/docs/linux/html/d7/d4f/struct_option_group_list.html
+++ b/docs/linux/html/d7/d4f/struct_option_group_list.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d60/struct_frame_data.html
+++ b/docs/linux/html/d7/d60/struct_frame_data.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/d9e/classffmpegkit_1_1_stream_information.html
+++ b/docs/linux/html/d7/d9e/classffmpegkit_1_1_stream_information.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/db2/struct_x_m_l_context.html
+++ b/docs/linux/html/d7/db2/struct_x_m_l_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/db3/fftools__ffmpeg_8h.html
+++ b/docs/linux/html/d7/db3/fftools__ffmpeg_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/db3/fftools__ffmpeg_8h_source.html
+++ b/docs/linux/html/d7/db3/fftools__ffmpeg_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -108,7 +108,7 @@ $(function() {
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - &quot;class&quot; member field renamed as clazz</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * - time field in set_report_callback updated as double</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d7/dc8/_arch_detect_8cpp.html
+++ b/docs/linux/html/d7/dc8/_arch_detect_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/dc8/_arch_detect_8cpp_source.html
+++ b/docs/linux/html/d7/dc8/_arch_detect_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/dc9/struct_demuxer.html
+++ b/docs/linux/html/d7/dc9/struct_demuxer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/dcc/fftools__cmdutils_8c.html
+++ b/docs/linux/html/d7/dcc/fftools__cmdutils_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/dcc/fftools__cmdutils_8c_source.html
+++ b/docs/linux/html/d7/dcc/fftools__cmdutils_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -99,15 +99,15 @@ $(function() {
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * This file is the modified version of cmdutils.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d7/dd8/fftools__objpool_8c.html
+++ b/docs/linux/html/d7/dd8/fftools__objpool_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d7/dd8/fftools__objpool_8c_source.html
+++ b/docs/linux/html/d7/dd8/fftools__objpool_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of objpool.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d8/d45/_f_fmpeg_kit_config_8cpp.html
+++ b/docs/linux/html/d8/d45/_f_fmpeg_kit_config_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d45/_f_fmpeg_kit_config_8cpp_source.html
+++ b/docs/linux/html/d8/d45/_f_fmpeg_kit_config_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -761,7 +761,7 @@ $(function() {
 <div class="line"><a id="l00770" name="l00770"></a><span class="lineno">  770</span> </div>
 <div class="line"><a id="l00771" name="l00771"></a><span class="lineno"><a class="line" href="../../d7/dc8/_arch_detect_8cpp.html#aa061971a1537d94184b8e552df340e9b">  771</a></span><span class="keywordtype">void</span>* <a class="code hl_function" href="../../d8/d45/_f_fmpeg_kit_config_8cpp.html#aa061971a1537d94184b8e552df340e9b">ffmpegKitInitialize</a>() {</div>
 <div class="line"><a id="l00772" name="l00772"></a><span class="lineno">  772</span>    std::call_once(<a class="code hl_variable" href="../../d8/d45/_f_fmpeg_kit_config_8cpp.html#a9b1c4cadb70f7472665f37c876d06642">ffmpegKitInitializerFlag</a>, [](){</div>
-<div class="line"><a id="l00773" name="l00773"></a><span class="lineno">  773</span>        std::cout &lt;&lt; <span class="stringliteral">&quot;Loading ffmpeg-kit.&quot;</span> &lt;&lt; std::endl;</div>
+<div class="line"><a id="l00773" name="l00773"></a><span class="lineno">  773</span>        std::cout &lt;&lt; <span class="stringliteral">&quot;Loading ffmpeg-kit-lib.&quot;</span> &lt;&lt; std::endl;</div>
 <div class="line"><a id="l00774" name="l00774"></a><span class="lineno">  774</span> </div>
 <div class="line"><a id="l00775" name="l00775"></a><span class="lineno">  775</span>        <a class="code hl_variable" href="../../d8/d45/_f_fmpeg_kit_config_8cpp.html#a24cad55e657bdaad060a621460d029f6">sessionHistorySize</a> = 10;</div>
 <div class="line"><a id="l00776" name="l00776"></a><span class="lineno">  776</span> </div>
@@ -782,7 +782,7 @@ $(function() {
 <div class="line"><a id="l00791" name="l00791"></a><span class="lineno">  791</span> </div>
 <div class="line"><a id="l00792" name="l00792"></a><span class="lineno">  792</span>        <a class="code hl_function" href="../../dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html#a38276361e645da189554ab37bc9a7b82">ffmpegkit::FFmpegKitConfig::enableRedirection</a>();</div>
 <div class="line"><a id="l00793" name="l00793"></a><span class="lineno">  793</span> </div>
-<div class="line"><a id="l00794" name="l00794"></a><span class="lineno">  794</span>        std::cout &lt;&lt; <span class="stringliteral">&quot;Loaded ffmpeg-kit-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../dd/dee/classffmpegkit_1_1_packages.html#a1903c222baa302b49faeccfc8afc0e59">ffmpegkit::Packages::getPackageName</a>() &lt;&lt; <span class="stringliteral">&quot;-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../d1/df7/classffmpegkit_1_1_arch_detect.html#aa8ec8ec6da18cda523df453b9fb3530c">ffmpegkit::ArchDetect::getArch</a>() &lt;&lt; <span class="stringliteral">&quot;-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html#a0c93081c2b97ba3f8440ea1ab28b7953">ffmpegkit::FFmpegKitConfig::getVersion</a>() &lt;&lt; <span class="stringliteral">&quot;-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html#ae81bcfffeb93c5154d4234ba5a449eb8">ffmpegkit::FFmpegKitConfig::getBuildDate</a>() &lt;&lt; <span class="stringliteral">&quot;.&quot;</span> &lt;&lt; std::endl;</div>
+<div class="line"><a id="l00794" name="l00794"></a><span class="lineno">  794</span>        std::cout &lt;&lt; <span class="stringliteral">&quot;Loaded ffmpeg-kit-lib-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../dd/dee/classffmpegkit_1_1_packages.html#a1903c222baa302b49faeccfc8afc0e59">ffmpegkit::Packages::getPackageName</a>() &lt;&lt; <span class="stringliteral">&quot;-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../d1/df7/classffmpegkit_1_1_arch_detect.html#aa8ec8ec6da18cda523df453b9fb3530c">ffmpegkit::ArchDetect::getArch</a>() &lt;&lt; <span class="stringliteral">&quot;-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html#a0c93081c2b97ba3f8440ea1ab28b7953">ffmpegkit::FFmpegKitConfig::getVersion</a>() &lt;&lt; <span class="stringliteral">&quot;-&quot;</span> &lt;&lt; <a class="code hl_function" href="../../dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html#ae81bcfffeb93c5154d4234ba5a449eb8">ffmpegkit::FFmpegKitConfig::getBuildDate</a>() &lt;&lt; <span class="stringliteral">&quot;.&quot;</span> &lt;&lt; std::endl;</div>
 <div class="line"><a id="l00795" name="l00795"></a><span class="lineno">  795</span>    });</div>
 <div class="line"><a id="l00796" name="l00796"></a><span class="lineno">  796</span> </div>
 <div class="line"><a id="l00797" name="l00797"></a><span class="lineno">  797</span>    <span class="keywordflow">return</span> NULL;</div>

--- a/docs/linux/html/d8/d4e/fftools__cmdutils_8h.html
+++ b/docs/linux/html/d8/d4e/fftools__cmdutils_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d4e/fftools__cmdutils_8h_source.html
+++ b/docs/linux/html/d8/d4e/fftools__cmdutils_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -99,15 +99,15 @@ $(function() {
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * This file is the modified version of cmdutils.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d8/d59/fftools__ffmpeg__mux__init_8c.html
+++ b/docs/linux/html/d8/d59/fftools__ffmpeg__mux__init_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d59/fftools__ffmpeg__mux__init_8c_source.html
+++ b/docs/linux/html/d8/d59/fftools__ffmpeg__mux__init_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_mux_init.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d8/d78/_f_fmpeg_kit_8cpp.html
+++ b/docs/linux/html/d8/d78/_f_fmpeg_kit_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d78/_f_fmpeg_kit_8cpp_source.html
+++ b/docs/linux/html/d8/d78/_f_fmpeg_kit_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d78/_media_information_8h.html
+++ b/docs/linux/html/d8/d78/_media_information_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d78/_media_information_8h_source.html
+++ b/docs/linux/html/d8/d78/_media_information_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d78/fftools__ffprobe_8c.html
+++ b/docs/linux/html/d8/d78/fftools__ffprobe_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/d78/fftools__ffprobe_8c_source.html
+++ b/docs/linux/html/d8/d78/fftools__ffprobe_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,16 +98,16 @@ $(function() {
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * This file is the modified version of ffprobe.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * - FFmpeg 6.0 changes migrated</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * - fftools header names updated</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00040" name="l00040"></a><span class="lineno">   40</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00041" name="l00041"></a><span class="lineno">   41</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00042" name="l00042"></a><span class="lineno">   42</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00043" name="l00043"></a><span class="lineno">   43</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d8/d99/struct_input_file.html
+++ b/docs/linux/html/d8/d99/struct_input_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d8/dee/struct_read_interval.html
+++ b/docs/linux/html/d8/dee/struct_read_interval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d11/structsection.html
+++ b/docs/linux/html/d9/d11/structsection.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d21/_return_code_8cpp.html
+++ b/docs/linux/html/d9/d21/_return_code_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d21/_return_code_8cpp_source.html
+++ b/docs/linux/html/d9/d21/_return_code_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d28/fftools__ffmpeg__demux_8c.html
+++ b/docs/linux/html/d9/d28/fftools__ffmpeg__demux_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d28/fftools__ffmpeg__demux_8c_source.html
+++ b/docs/linux/html/d9/d28/fftools__ffmpeg__demux_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -96,9 +96,9 @@ $(function() {
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * This file is the modified version of ffmpeg_demux.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/d9/d28/struct_sync_queue.html
+++ b/docs/linux/html/d9/d28/struct_sync_queue.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d6c/struct_demux_msg.html
+++ b/docs/linux/html/d9/d6c/struct_demux_msg.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d6d/structunit__value.html
+++ b/docs/linux/html/d9/d6d/structunit__value.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d76/_abstract_session_8h.html
+++ b/docs/linux/html/d9/d76/_abstract_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d76/_abstract_session_8h_source.html
+++ b/docs/linux/html/d9/d76/_abstract_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d8b/_f_fprobe_session_8cpp.html
+++ b/docs/linux/html/d9/d8b/_f_fprobe_session_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d8b/_f_fprobe_session_8cpp_source.html
+++ b/docs/linux/html/d9/d8b/_f_fprobe_session_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/d9f/classffmpegkit_1_1_chapter.html
+++ b/docs/linux/html/d9/d9f/classffmpegkit_1_1_chapter.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/db4/struct_thread_queue.html
+++ b/docs/linux/html/d9/db4/struct_thread_queue.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/d9/de7/struct_filter_graph.html
+++ b/docs/linux/html/d9/de7/struct_filter_graph.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d27/structffmpegkit_1_1_media_information_session_1_1_public_media_information_session.html
+++ b/docs/linux/html/da/d27/structffmpegkit_1_1_media_information_session_1_1_public_media_information_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Linux API
    &#160;<span id="projectnumber">4.5.1</span>

--- a/docs/linux/html/da/d2c/fftools__opt__common_8c.html
+++ b/docs/linux/html/da/d2c/fftools__opt__common_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d2c/fftools__opt__common_8c_source.html
+++ b/docs/linux/html/da/d2c/fftools__opt__common_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,15 +98,15 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of opt_common.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop the ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop the ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
 <div class="line"><a id="l00032" name="l00032"></a><span class="lineno">   32</span><span class="comment"> * - time field in report_callback updated as double</span></div>
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * 09.2022</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/da/d4f/struct_i_n_i_context.html
+++ b/docs/linux/html/da/d4f/struct_i_n_i_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d53/classffmpegkit_1_1_media_information_json_parser.html
+++ b/docs/linux/html/da/d53/classffmpegkit_1_1_media_information_json_parser.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d56/struct_enc_stats_file.html
+++ b/docs/linux/html/da/d56/struct_enc_stats_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d5c/classffmpegkit_1_1_f_fprobe_session.html
+++ b/docs/linux/html/da/d5c/classffmpegkit_1_1_f_fprobe_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d62/struct_fifo_elem.html
+++ b/docs/linux/html/da/d62/struct_fifo_elem.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d66/fftools__ffmpeg__opt_8c.html
+++ b/docs/linux/html/da/d66/fftools__ffmpeg__opt_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d66/fftools__ffmpeg__opt_8c_source.html
+++ b/docs/linux/html/da/d66/fftools__ffmpeg__opt_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -98,9 +98,9 @@ $(function() {
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * This file is the modified version of ffmpeg_opt.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.</span></div>
+<div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00031" name="l00031"></a><span class="lineno">   31</span><span class="comment"> * --------------------------------------------------------</span></div>
@@ -108,7 +108,7 @@ $(function() {
 <div class="line"><a id="l00033" name="l00033"></a><span class="lineno">   33</span><span class="comment"> * - include fftools_ffmpeg_mux.h added</span></div>
 <div class="line"><a id="l00034" name="l00034"></a><span class="lineno">   34</span><span class="comment"> * - fftools header names updated</span></div>
 <div class="line"><a id="l00035" name="l00035"></a><span class="lineno">   35</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener</span></div>
+<div class="line"><a id="l00036" name="l00036"></a><span class="lineno">   36</span><span class="comment"> * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener</span></div>
 <div class="line"><a id="l00037" name="l00037"></a><span class="lineno">   37</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00038" name="l00038"></a><span class="lineno">   38</span><span class="comment"> * 08.2020</span></div>
 <div class="line"><a id="l00039" name="l00039"></a><span class="lineno">   39</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/da/d87/fftools__thread__queue_8h.html
+++ b/docs/linux/html/da/d87/fftools__thread__queue_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/d87/fftools__thread__queue_8h_source.html
+++ b/docs/linux/html/da/d87/fftools__thread__queue_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of thread_queue.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/da/df2/_statistics_8h.html
+++ b/docs/linux/html/da/df2/_statistics_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/df2/_statistics_8h_source.html
+++ b/docs/linux/html/da/df2/_statistics_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/df4/_log_8h.html
+++ b/docs/linux/html/da/df4/_log_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/df4/_log_8h_source.html
+++ b/docs/linux/html/da/df4/_log_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/dfd/_abstract_session_8cpp.html
+++ b/docs/linux/html/da/dfd/_abstract_session_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/da/dfd/_abstract_session_8cpp_source.html
+++ b/docs/linux/html/da/dfd/_abstract_session_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/d1c/classffmpegkit_1_1_log.html
+++ b/docs/linux/html/db/d1c/classffmpegkit_1_1_log.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/d60/struct_stream_map.html
+++ b/docs/linux/html/db/d60/struct_stream_map.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/d71/classffmpegkit_1_1_f_fmpeg_kit.html
+++ b/docs/linux/html/db/d71/classffmpegkit_1_1_f_fmpeg_kit.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/db5/struct_option_parse_context.html
+++ b/docs/linux/html/db/db5/struct_option_parse_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/dbb/struct_enc_stats.html
+++ b/docs/linux/html/db/dbb/struct_enc_stats.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/dd7/struct_option_group_def.html
+++ b/docs/linux/html/db/dd7/struct_option_group_def.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/db/dde/struct_output_stream.html
+++ b/docs/linux/html/db/dde/struct_output_stream.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/d16/struct_last_frame_duration.html
+++ b/docs/linux/html/dc/d16/struct_last_frame_duration.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/d1e/struct_option_def.html
+++ b/docs/linux/html/dc/d1e/struct_option_def.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html
+++ b/docs/linux/html/dc/d2a/classffmpegkit_1_1_f_fmpeg_kit_config.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -1802,7 +1802,7 @@ Static Public Attributes</h2></td></tr>
   </tr>
 </table>
 </div><div class="memdoc">
-<p>Prefix of named pipes created by ffmpeg-kit. </p>
+<p>Prefix of named pipes created by ffmpeg-kit-lib. </p>
 
 <p class="definition">Definition at line <a class="el" href="../../df/d48/_f_fmpeg_kit_config_8h_source.html#l00050">50</a> of file <a class="el" href="../../df/d48/_f_fmpeg_kit_config_8h_source.html">FFmpegKitConfig.h</a>.</p>
 

--- a/docs/linux/html/dc/d56/fftools__thread__queue_8c.html
+++ b/docs/linux/html/dc/d56/fftools__thread__queue_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/d56/fftools__thread__queue_8c_source.html
+++ b/docs/linux/html/dc/d56/fftools__thread__queue_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of thread_queue.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/dc/d8d/_chapter_8h.html
+++ b/docs/linux/html/dc/d8d/_chapter_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/d8d/_chapter_8h_source.html
+++ b/docs/linux/html/dc/d8d/_chapter_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/da0/_f_fprobe_session_8h.html
+++ b/docs/linux/html/dc/da0/_f_fprobe_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/da0/_f_fprobe_session_8h_source.html
+++ b/docs/linux/html/dc/da0/_f_fprobe_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dc/df8/union_sync_queue_frame.html
+++ b/docs/linux/html/dc/df8/union_sync_queue_frame.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dd/d0c/struct_enc_stats_component.html
+++ b/docs/linux/html/dd/d0c/struct_enc_stats_component.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dd/d15/struct_log_buffer.html
+++ b/docs/linux/html/dd/d15/struct_log_buffer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dd/d69/_media_information_session_8h.html
+++ b/docs/linux/html/dd/d69/_media_information_session_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dd/d69/_media_information_session_8h_source.html
+++ b/docs/linux/html/dd/d69/_media_information_session_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dd/da5/struct_specifier_opt.html
+++ b/docs/linux/html/dd/da5/struct_specifier_opt.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/dd/dee/classffmpegkit_1_1_packages.html
+++ b/docs/linux/html/dd/dee/classffmpegkit_1_1_packages.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/de/d29/struct_muxer.html
+++ b/docs/linux/html/de/d29/struct_muxer.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/de/d78/structffmpegkit_1_1_f_fmpeg_session_1_1_public_f_fmpeg_session.html
+++ b/docs/linux/html/de/d78/structffmpegkit_1_1_f_fmpeg_session_1_1_public_f_fmpeg_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Linux API
    &#160;<span id="projectnumber">4.5.1</span>

--- a/docs/linux/html/de/dc7/struct_h_w_device.html
+++ b/docs/linux/html/de/dc7/struct_h_w_device.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/de/df2/struct_output_file.html
+++ b/docs/linux/html/de/df2/struct_output_file.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d06/classffmpegkit_1_1_media_information.html
+++ b/docs/linux/html/df/d06/classffmpegkit_1_1_media_information.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d13/_session_state_8h.html
+++ b/docs/linux/html/df/d13/_session_state_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d13/_session_state_8h_source.html
+++ b/docs/linux/html/df/d13/_session_state_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d2b/_f_fmpeg_session_8cpp.html
+++ b/docs/linux/html/df/d2b/_f_fmpeg_session_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d2b/_f_fmpeg_session_8cpp_source.html
+++ b/docs/linux/html/df/d2b/_f_fmpeg_session_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d2b/fftools__ffmpeg__mux_8h.html
+++ b/docs/linux/html/df/d2b/fftools__ffmpeg__mux_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d2b/fftools__ffmpeg__mux_8h_source.html
+++ b/docs/linux/html/df/d2b/fftools__ffmpeg__mux_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -97,9 +97,9 @@ $(function() {
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * This file is the modified version of ffmpeg_mux.h file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00029" name="l00029"></a><span class="lineno">   29</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00030" name="l00030"></a><span class="lineno">   30</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/df/d37/struct_h_w_accel.html
+++ b/docs/linux/html/df/d37/struct_h_w_accel.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr style="height: 56px;">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign" style="padding-left: 0.5em;">
    <div id="projectname">FFmpegKit Linux API
    &#160;<span id="projectnumber">4.5.1</span>

--- a/docs/linux/html/df/d3f/classffmpegkit_1_1_f_fprobe_kit.html
+++ b/docs/linux/html/df/d3f/classffmpegkit_1_1_f_fprobe_kit.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d40/ffmpegkit__exception_8cpp.html
+++ b/docs/linux/html/df/d40/ffmpegkit__exception_8cpp.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d40/ffmpegkit__exception_8cpp_source.html
+++ b/docs/linux/html/df/d40/ffmpegkit__exception_8cpp_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d48/_f_fmpeg_kit_config_8h.html
+++ b/docs/linux/html/df/d48/_f_fmpeg_kit_config_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d48/_f_fmpeg_kit_config_8h_source.html
+++ b/docs/linux/html/df/d48/_f_fmpeg_kit_config_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d57/_media_information_session_complete_callback_8h.html
+++ b/docs/linux/html/df/d57/_media_information_session_complete_callback_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d57/_media_information_session_complete_callback_8h_source.html
+++ b/docs/linux/html/df/d57/_media_information_session_complete_callback_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d77/struct_options_context.html
+++ b/docs/linux/html/df/d77/struct_options_context.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d99/_f_fmpeg_kit_8h.html
+++ b/docs/linux/html/df/d99/_f_fmpeg_kit_8h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/d99/_f_fmpeg_kit_8h_source.html
+++ b/docs/linux/html/df/d99/_f_fmpeg_kit_8h_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/db7/classffmpegkit_1_1_media_information_session.html
+++ b/docs/linux/html/df/db7/classffmpegkit_1_1_media_information_session.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/dbb/fftools__sync__queue_8c.html
+++ b/docs/linux/html/df/dbb/fftools__sync__queue_8c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/df/dbb/fftools__sync__queue_8c_source.html
+++ b/docs/linux/html/df/dbb/fftools__sync__queue_8c_source.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="../../ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>
@@ -95,9 +95,9 @@ $(function() {
 <div class="line"><a id="l00020" name="l00020"></a><span class="lineno">   20</span><span class="comment">/*</span></div>
 <div class="line"><a id="l00021" name="l00021"></a><span class="lineno">   21</span><span class="comment"> * This file is the modified version of sync_queue.c file living in ffmpeg source code under the fftools folder. We</span></div>
 <div class="line"><a id="l00022" name="l00022"></a><span class="lineno">   22</span><span class="comment"> * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied</span></div>
-<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit library.</span></div>
+<div class="line"><a id="l00023" name="l00023"></a><span class="lineno">   23</span><span class="comment"> * by us to develop ffmpeg-kit-lib library.</span></div>
 <div class="line"><a id="l00024" name="l00024"></a><span class="lineno">   24</span><span class="comment"> *</span></div>
-<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit changes by ARTHENICA LTD</span></div>
+<div class="line"><a id="l00025" name="l00025"></a><span class="lineno">   25</span><span class="comment"> * ffmpeg-kit-lib changes by ARTHENICA LTD</span></div>
 <div class="line"><a id="l00026" name="l00026"></a><span class="lineno">   26</span><span class="comment"> *</span></div>
 <div class="line"><a id="l00027" name="l00027"></a><span class="lineno">   27</span><span class="comment"> * 07.2023</span></div>
 <div class="line"><a id="l00028" name="l00028"></a><span class="lineno">   28</span><span class="comment"> * --------------------------------------------------------</span></div>

--- a/docs/linux/html/files.html
+++ b/docs/linux/html/files.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions.html
+++ b/docs/linux/html/functions.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_a.html
+++ b/docs/linux/html/functions_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_b.html
+++ b/docs/linux/html/functions_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_c.html
+++ b/docs/linux/html/functions_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_d.html
+++ b/docs/linux/html/functions_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_e.html
+++ b/docs/linux/html/functions_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_f.html
+++ b/docs/linux/html/functions_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func.html
+++ b/docs/linux/html/functions_func.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_c.html
+++ b/docs/linux/html/functions_func_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_d.html
+++ b/docs/linux/html/functions_func_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_e.html
+++ b/docs/linux/html/functions_func_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_f.html
+++ b/docs/linux/html/functions_func_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_g.html
+++ b/docs/linux/html/functions_func_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_i.html
+++ b/docs/linux/html/functions_func_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_l.html
+++ b/docs/linux/html/functions_func_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_m.html
+++ b/docs/linux/html/functions_func_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_p.html
+++ b/docs/linux/html/functions_func_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_r.html
+++ b/docs/linux/html/functions_func_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_s.html
+++ b/docs/linux/html/functions_func_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_t.html
+++ b/docs/linux/html/functions_func_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_func_w.html
+++ b/docs/linux/html/functions_func_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_g.html
+++ b/docs/linux/html/functions_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_h.html
+++ b/docs/linux/html/functions_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_i.html
+++ b/docs/linux/html/functions_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_k.html
+++ b/docs/linux/html/functions_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_l.html
+++ b/docs/linux/html/functions_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_m.html
+++ b/docs/linux/html/functions_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_n.html
+++ b/docs/linux/html/functions_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_o.html
+++ b/docs/linux/html/functions_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_p.html
+++ b/docs/linux/html/functions_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_q.html
+++ b/docs/linux/html/functions_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_r.html
+++ b/docs/linux/html/functions_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_rela.html
+++ b/docs/linux/html/functions_rela.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_s.html
+++ b/docs/linux/html/functions_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_t.html
+++ b/docs/linux/html/functions_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_u.html
+++ b/docs/linux/html/functions_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_v.html
+++ b/docs/linux/html/functions_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars.html
+++ b/docs/linux/html/functions_vars.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_a.html
+++ b/docs/linux/html/functions_vars_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_b.html
+++ b/docs/linux/html/functions_vars_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_c.html
+++ b/docs/linux/html/functions_vars_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_d.html
+++ b/docs/linux/html/functions_vars_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_e.html
+++ b/docs/linux/html/functions_vars_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_f.html
+++ b/docs/linux/html/functions_vars_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_g.html
+++ b/docs/linux/html/functions_vars_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_h.html
+++ b/docs/linux/html/functions_vars_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_i.html
+++ b/docs/linux/html/functions_vars_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_k.html
+++ b/docs/linux/html/functions_vars_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_l.html
+++ b/docs/linux/html/functions_vars_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_m.html
+++ b/docs/linux/html/functions_vars_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_n.html
+++ b/docs/linux/html/functions_vars_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_o.html
+++ b/docs/linux/html/functions_vars_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_p.html
+++ b/docs/linux/html/functions_vars_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_q.html
+++ b/docs/linux/html/functions_vars_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_r.html
+++ b/docs/linux/html/functions_vars_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_s.html
+++ b/docs/linux/html/functions_vars_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_t.html
+++ b/docs/linux/html/functions_vars_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_u.html
+++ b/docs/linux/html/functions_vars_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_v.html
+++ b/docs/linux/html/functions_vars_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_w.html
+++ b/docs/linux/html/functions_vars_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_vars_x.html
+++ b/docs/linux/html/functions_vars_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_w.html
+++ b/docs/linux/html/functions_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/functions_x.html
+++ b/docs/linux/html/functions_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals.html
+++ b/docs/linux/html/globals.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_a.html
+++ b/docs/linux/html/globals_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_b.html
+++ b/docs/linux/html/globals_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_c.html
+++ b/docs/linux/html/globals_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_d.html
+++ b/docs/linux/html/globals_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_defs.html
+++ b/docs/linux/html/globals_defs.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_e.html
+++ b/docs/linux/html/globals_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_enum.html
+++ b/docs/linux/html/globals_enum.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_eval.html
+++ b/docs/linux/html/globals_eval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_f.html
+++ b/docs/linux/html/globals_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func.html
+++ b/docs/linux/html/globals_func.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_b.html
+++ b/docs/linux/html/globals_func_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_c.html
+++ b/docs/linux/html/globals_func_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_d.html
+++ b/docs/linux/html/globals_func_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_e.html
+++ b/docs/linux/html/globals_func_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_f.html
+++ b/docs/linux/html/globals_func_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_g.html
+++ b/docs/linux/html/globals_func_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_h.html
+++ b/docs/linux/html/globals_func_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_i.html
+++ b/docs/linux/html/globals_func_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_j.html
+++ b/docs/linux/html/globals_func_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_l.html
+++ b/docs/linux/html/globals_func_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_m.html
+++ b/docs/linux/html/globals_func_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_n.html
+++ b/docs/linux/html/globals_func_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_o.html
+++ b/docs/linux/html/globals_func_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_p.html
+++ b/docs/linux/html/globals_func_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_q.html
+++ b/docs/linux/html/globals_func_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_r.html
+++ b/docs/linux/html/globals_func_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_s.html
+++ b/docs/linux/html/globals_func_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_t.html
+++ b/docs/linux/html/globals_func_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_u.html
+++ b/docs/linux/html/globals_func_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_v.html
+++ b/docs/linux/html/globals_func_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_w.html
+++ b/docs/linux/html/globals_func_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_func_x.html
+++ b/docs/linux/html/globals_func_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_g.html
+++ b/docs/linux/html/globals_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_h.html
+++ b/docs/linux/html/globals_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_i.html
+++ b/docs/linux/html/globals_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_j.html
+++ b/docs/linux/html/globals_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_k.html
+++ b/docs/linux/html/globals_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_l.html
+++ b/docs/linux/html/globals_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_m.html
+++ b/docs/linux/html/globals_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_n.html
+++ b/docs/linux/html/globals_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_o.html
+++ b/docs/linux/html/globals_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_p.html
+++ b/docs/linux/html/globals_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_q.html
+++ b/docs/linux/html/globals_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_r.html
+++ b/docs/linux/html/globals_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_s.html
+++ b/docs/linux/html/globals_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_t.html
+++ b/docs/linux/html/globals_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_type.html
+++ b/docs/linux/html/globals_type.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_u.html
+++ b/docs/linux/html/globals_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_v.html
+++ b/docs/linux/html/globals_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars.html
+++ b/docs/linux/html/globals_vars.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_a.html
+++ b/docs/linux/html/globals_vars_a.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_b.html
+++ b/docs/linux/html/globals_vars_b.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_c.html
+++ b/docs/linux/html/globals_vars_c.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_d.html
+++ b/docs/linux/html/globals_vars_d.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_e.html
+++ b/docs/linux/html/globals_vars_e.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_f.html
+++ b/docs/linux/html/globals_vars_f.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_g.html
+++ b/docs/linux/html/globals_vars_g.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_h.html
+++ b/docs/linux/html/globals_vars_h.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_i.html
+++ b/docs/linux/html/globals_vars_i.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_j.html
+++ b/docs/linux/html/globals_vars_j.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_k.html
+++ b/docs/linux/html/globals_vars_k.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_l.html
+++ b/docs/linux/html/globals_vars_l.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_m.html
+++ b/docs/linux/html/globals_vars_m.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_n.html
+++ b/docs/linux/html/globals_vars_n.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_o.html
+++ b/docs/linux/html/globals_vars_o.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_p.html
+++ b/docs/linux/html/globals_vars_p.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_q.html
+++ b/docs/linux/html/globals_vars_q.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_r.html
+++ b/docs/linux/html/globals_vars_r.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_s.html
+++ b/docs/linux/html/globals_vars_s.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_t.html
+++ b/docs/linux/html/globals_vars_t.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_u.html
+++ b/docs/linux/html/globals_vars_u.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_v.html
+++ b/docs/linux/html/globals_vars_v.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_w.html
+++ b/docs/linux/html/globals_vars_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_vars_x.html
+++ b/docs/linux/html/globals_vars_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_w.html
+++ b/docs/linux/html/globals_w.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/globals_x.html
+++ b/docs/linux/html/globals_x.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/hierarchy.html
+++ b/docs/linux/html/hierarchy.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/index.html
+++ b/docs/linux/html/index.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/namespacemembers.html
+++ b/docs/linux/html/namespacemembers.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/namespacemembers_enum.html
+++ b/docs/linux/html/namespacemembers_enum.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/namespacemembers_eval.html
+++ b/docs/linux/html/namespacemembers_eval.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/namespacemembers_func.html
+++ b/docs/linux/html/namespacemembers_func.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/namespacemembers_type.html
+++ b/docs/linux/html/namespacemembers_type.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/docs/linux/html/namespaces.html
+++ b/docs/linux/html/namespaces.html
@@ -20,7 +20,7 @@
 <table cellspacing="0" cellpadding="0">
  <tbody>
  <tr id="projectrow">
-  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-icon-v9-small.png"/></td>
+  <td id="projectlogo"><img alt="Logo" src="ffmpeg-kit-lib-icon-v9-small.png"/></td>
   <td id="projectalign">
    <div id="projectname">FFmpegKit Linux API<span id="projectnumber">&#160;6.0</span>
    </div>

--- a/flutter/flutter/README.md
+++ b/flutter/flutter/README.md
@@ -46,9 +46,9 @@ to be enabled in order to encode specific formats/codecs. For example, to encode
 encode an `h264` video, you need to install a package with `x264` inside. To encode `vp8` or `vp9` videos, you need
 a `ffmpeg_kit_flutter` package with `libvpx` inside.
 
-`ffmpeg-kit` provides eight packages that include different sets of external libraries. These packages are named
+`ffmpeg-kit-lib` provides eight packages that include different sets of external libraries. These packages are named
 according to the external libraries included. Refer to the
-[Packages](https://github.com/arthenica/ffmpeg-kit/wiki/Packages) wiki page to see the names of those
+[Packages](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Packages) wiki page to see the names of those
 packages and external libraries included in each one of them.
 
 #### 2.2 Installing Packages
@@ -77,7 +77,7 @@ dependencies:
 
 `ffmpeg_kit_flutter` is published in two variants: `Main Release` and `LTS Release`. Both releases share the
 same source code but is built with different settings (Architectures, API Level, iOS Min SDK, etc.). Refer to the
-[LTS Releases](https://github.com/arthenica/ffmpeg-kit/wiki/LTS-Releases) wiki page to see how they differ from each
+[LTS Releases](https://github.com/arthenica/ffmpeg-kit-lib/wiki/LTS-Releases) wiki page to see how they differ from each
 other.
 
 #### 2.5 Platform Support
@@ -320,16 +320,16 @@ The following table shows Android API level, iOS deployment target and macOS dep
 ### 4. Test Application
 
 You can see how `FFmpegKit` is used inside an application by running `flutter` test applications developed under
-the [FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+the [FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.
 
 ### 5. Tips
 
-See [Tips](https://github.com/arthenica/ffmpeg-kit/wiki/Tips) wiki page.
+See [Tips](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Tips) wiki page.
 
 ### 6. License
 
-See [License](https://github.com/arthenica/ffmpeg-kit/wiki/License) wiki page.
+See [License](https://github.com/arthenica/ffmpeg-kit-lib/wiki/License) wiki page.
 
 ### 7. Patents
 
-See [Patents](https://github.com/arthenica/ffmpeg-kit/wiki/Patents) wiki page.
+See [Patents](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Patents) wiki page.

--- a/flutter/flutter/android/build.gradle
+++ b/flutter/flutter/android/build.gradle
@@ -49,5 +49,5 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.5.0'
-    implementation 'com.arthenica:ffmpeg-kit-https:6.0-2'
+    implementation 'com.arthenica:ffmpeg-kit-lib-https:6.0-2'
 }

--- a/flutter/flutter/android/settings.gradle
+++ b/flutter/flutter/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'ffmpeg-kit-flutter-android'
+rootProject.name = 'ffmpeg-kit-lib-flutter-android'

--- a/flutter/flutter/android/src/main/java/com/arthenica/ffmpegkit/flutter/FFmpegKitFlutterPlugin.java
+++ b/flutter/flutter/android/src/main/java/com/arthenica/ffmpegkit/flutter/FFmpegKitFlutterPlugin.java
@@ -77,7 +77,7 @@ import io.flutter.plugin.common.PluginRegistry;
 
 public class FFmpegKitFlutterPlugin implements FlutterPlugin, ActivityAware, MethodCallHandler, EventChannel.StreamHandler, PluginRegistry.ActivityResultListener {
 
-    public static final String LIBRARY_NAME = "ffmpeg-kit-flutter";
+    public static final String LIBRARY_NAME = "ffmpeg-kit-lib-flutter";
     public static final String PLATFORM_NAME = "android";
 
     private static final String METHOD_CHANNEL = "flutter.arthenica.com/ffmpeg_kit";

--- a/flutter/flutter/ios/ffmpeg_kit_flutter.podspec
+++ b/flutter/flutter/ios/ffmpeg_kit_flutter.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version          = '6.0.3'
   s.summary          = 'FFmpeg Kit for Flutter'
   s.description      = 'A Flutter plugin for running FFmpeg and FFprobe commands.'
-  s.homepage         = 'https://github.com/arthenica/ffmpeg-kit'
+  s.homepage         = 'https://github.com/arthenica/ffmpeg-kit-lib'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'ARTHENICA' => 'open-source@arthenica.com' }
 
@@ -23,112 +23,112 @@ Pod::Spec.new do |s|
   s.subspec 'min' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-min', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-min', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'min-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-min', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-min', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'min-gpl' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-min-gpl', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-min-gpl', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'min-gpl-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-min-gpl', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-min-gpl', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'https' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-https', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-https', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'https-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-https', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-https', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'https-gpl' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-https-gpl', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-https-gpl', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'https-gpl-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-https-gpl', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-https-gpl', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'audio' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-audio', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-audio', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'audio-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-audio', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-audio', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'video' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-video', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-video', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'video-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-video', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-video', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'full' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-full', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-full', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'full-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-full', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-full', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 
   s.subspec 'full-gpl' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-full-gpl', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-ios-full-gpl', "6.0"
     ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'full-gpl-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-ios-full-gpl', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-ios-full-gpl', "6.0.LTS"
     ss.ios.deployment_target = '10'
   end
 

--- a/flutter/flutter/lib/src/ffmpeg_kit_flutter_initializer.dart
+++ b/flutter/flutter/lib/src/ffmpeg_kit_flutter_initializer.dart
@@ -306,7 +306,7 @@ class FFmpegKitInitializer {
   }
 
   Future<void> _initialize() async {
-    print("Loading ffmpeg-kit-flutter.");
+    print("Loading ffmpeg-kit-lib-flutter.");
 
     _eventChannel.receiveBroadcastStream().listen(_onEvent, onError: _onError);
 
@@ -322,6 +322,6 @@ class FFmpegKitInitializer {
     final isLTSPostfix = (await FFmpegKitConfig.isLTSBuild()) ? "-lts" : "";
 
     final fullVersion = "$platform-$packageName-$arch-$version$isLTSPostfix";
-    print("Loaded ffmpeg-kit-flutter-$fullVersion.");
+    print("Loaded ffmpeg-kit-lib-flutter-$fullVersion.");
   }
 }

--- a/flutter/flutter/macos/ffmpeg_kit_flutter.podspec
+++ b/flutter/flutter/macos/ffmpeg_kit_flutter.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version          = '6.0.3'
   s.summary          = 'FFmpeg Kit for Flutter'
   s.description      = 'A Flutter plugin for running FFmpeg and FFprobe commands.'
-  s.homepage         = 'https://github.com/arthenica/ffmpeg-kit'
+  s.homepage         = 'https://github.com/arthenica/ffmpeg-kit-lib'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'ARTHENICA' => 'open-source@arthenica.com' }
 
@@ -23,112 +23,112 @@ Pod::Spec.new do |s|
   s.subspec 'min' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-min', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-min', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'min-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-min', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-min', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'min-gpl' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-min-gpl', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-min-gpl', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'min-gpl-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-min-gpl', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-min-gpl', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'https' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-https', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-https', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'https-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-https', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-https', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'https-gpl' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-https-gpl', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-https-gpl', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'https-gpl-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-https-gpl', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-https-gpl', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'audio' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-audio', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-audio', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'audio-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-audio', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-audio', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'video' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-video', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-video', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'video-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-video', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-video', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'full' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-full', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-full', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'full-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-full', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-full', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 
   s.subspec 'full-gpl' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-full-gpl', "6.0"
+    ss.dependency 'ffmpeg-kit-lib-macos-full-gpl', "6.0"
     ss.osx.deployment_target = '10.15'
   end
 
   s.subspec 'full-gpl-lts' do |ss|
     ss.source_files         = 'Classes/**/*'
     ss.public_header_files  = 'Classes/**/*.h'
-    ss.dependency 'ffmpeg-kit-macos-full-gpl', "6.0.LTS"
+    ss.dependency 'ffmpeg-kit-lib-macos-full-gpl', "6.0.LTS"
     ss.osx.deployment_target = '10.12'
   end
 

--- a/flutter/flutter/pubspec.yaml
+++ b/flutter/flutter/pubspec.yaml
@@ -1,8 +1,8 @@
 name: ffmpeg_kit_flutter
 description: FFmpeg Kit for Flutter. Supports Android, iOS and macOS platforms.
-repository: https://github.com/arthenica/ffmpeg-kit
-issue_tracker: https://github.com/arthenica/ffmpeg-kit/issues
-homepage: https://github.com/arthenica/ffmpeg-kit
+repository: https://github.com/arthenica/ffmpeg-kit-lib
+issue_tracker: https://github.com/arthenica/ffmpeg-kit-lib/issues
+homepage: https://github.com/arthenica/ffmpeg-kit-lib
 version: 6.0.3
 
 environment:

--- a/flutter/flutter_platform_interface/pubspec.yaml
+++ b/flutter/flutter_platform_interface/pubspec.yaml
@@ -1,8 +1,8 @@
 name: ffmpeg_kit_flutter_platform_interface
 description: A common platform interface for ffmpeg_kit_flutter plugin.
-repository: https://github.com/arthenica/ffmpeg-kit
-issue_tracker: https://github.com/arthenica/ffmpeg-kit/issues
-homepage: https://github.com/arthenica/ffmpeg-kit
+repository: https://github.com/arthenica/ffmpeg-kit-lib
+issue_tracker: https://github.com/arthenica/ffmpeg-kit-lib/issues
+homepage: https://github.com/arthenica/ffmpeg-kit-lib
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 version: 0.2.1

--- a/ios.sh
+++ b/ios.sh
@@ -212,8 +212,8 @@ if [[ ${NO_FRAMEWORK} -ne 1 ]] && [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABL
   disable_arch "arm64-simulator"
 fi
 
-echo -e "\nBuilding ffmpeg-kit ${BUILD_TYPE_ID}shared library for iOS\n"
-echo -e -n "INFO: Building ffmpeg-kit ${BUILD_VERSION} ${BUILD_TYPE_ID}for iOS: " 1>>"${BASEDIR}"/build.log 2>&1
+echo -e "\nBuilding ffmpeg-kit-lib ${BUILD_TYPE_ID}shared library for iOS\n"
+echo -e -n "INFO: Building ffmpeg-kit-lib ${BUILD_VERSION} ${BUILD_TYPE_ID}for iOS: " 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "$(date)\n" 1>>"${BASEDIR}"/build.log 2>&1
 
 # PRINT BUILD SUMMARY

--- a/linux.sh
+++ b/linux.sh
@@ -144,8 +144,8 @@ if [[ -n ${DISPLAY_HELP} ]]; then
   exit 0
 fi
 
-echo -e "\nBuilding ffmpeg-kit ${BUILD_TYPE_ID}library for Linux\n"
-echo -e -n "INFO: Building ffmpeg-kit ${BUILD_VERSION} ${BUILD_TYPE_ID}library for Linux: " 1>>"${BASEDIR}"/build.log 2>&1
+echo -e "\nBuilding ffmpeg-kit-lib ${BUILD_TYPE_ID}library for Linux\n"
+echo -e -n "INFO: Building ffmpeg-kit-lib ${BUILD_VERSION} ${BUILD_TYPE_ID}library for Linux: " 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "$(date)\n" 1>>"${BASEDIR}"/build.log 2>&1
 
 # PRINT BUILD SUMMARY

--- a/linux/Doxyfile
+++ b/linux/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_BRIEF          =
 # pixels and the maximum width should not exceed 200 pixels. Doxygen will copy
 # the logo to the output directory.
 
-PROJECT_LOGO           = ../docs/assets/ffmpeg-kit-icon-v9-small.png
+PROJECT_LOGO           = ../docs/assets/ffmpeg-kit-lib-icon-v9-small.png
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute) path
 # into which the generated documentation will be written. If a relative path is

--- a/linux/README.md
+++ b/linux/README.md
@@ -8,7 +8,7 @@
 
 ### 2. Building
 
-Run `linux.sh` at project root directory to build `ffmpeg-kit` and `ffmpeg` shared libraries. 
+Run `linux.sh` at project root directory to build `ffmpeg-kit-lib` and `ffmpeg` shared libraries. 
 
 Please note that `FFmpegKit` project repository includes the source code of `FFmpegKit` only. `linux.sh` needs 
 network connectivity and internet access to `github.com` in order to download the source code of `FFmpeg` and 
@@ -282,4 +282,4 @@ Then, you can use the following API methods to execute `FFmpeg` and `FFprobe` co
 ### 4. Test Application
 
 You can see how `FFmpegKit` is used inside an application by running `Linux` test applications developed under the
-[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+[FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.

--- a/linux/configure.ac
+++ b/linux/configure.ac
@@ -1,6 +1,6 @@
-# ffmpeg-kit 6.0 configure.ac
+# ffmpeg-kit-lib 6.0 configure.ac
 
-AC_INIT([ffmpeg-kit], [6.0], [https://github.com/arthenica/ffmpeg-kit/issues/new])
+AC_INIT([ffmpeg-kit-lib], [6.0], [https://github.com/arthenica/ffmpeg-kit-lib/issues/new])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/FFmpegKit.cpp])
 

--- a/linux/src/FFmpegKitConfig.cpp
+++ b/linux/src/FFmpegKitConfig.cpp
@@ -770,7 +770,7 @@ int executeFFprobe(const long sessionId, const std::shared_ptr<std::list<std::st
 
 void* ffmpegKitInitialize() {
     std::call_once(ffmpegKitInitializerFlag, [](){
-        std::cout << "Loading ffmpeg-kit." << std::endl;
+        std::cout << "Loading ffmpeg-kit-lib." << std::endl;
 
         sessionHistorySize = 10;
 
@@ -791,7 +791,7 @@ void* ffmpegKitInitialize() {
 
         ffmpegkit::FFmpegKitConfig::enableRedirection();
 
-        std::cout << "Loaded ffmpeg-kit-" << ffmpegkit::Packages::getPackageName() << "-" << ffmpegkit::ArchDetect::getArch() << "-" << ffmpegkit::FFmpegKitConfig::getVersion() << "-" << ffmpegkit::FFmpegKitConfig::getBuildDate() << "." << std::endl;
+        std::cout << "Loaded ffmpeg-kit-lib-" << ffmpegkit::Packages::getPackageName() << "-" << ffmpegkit::ArchDetect::getArch() << "-" << ffmpegkit::FFmpegKitConfig::getVersion() << "-" << ffmpegkit::FFmpegKitConfig::getBuildDate() << "." << std::endl;
     });
 
     return NULL;

--- a/linux/src/FFmpegKitConfig.h
+++ b/linux/src/FFmpegKitConfig.h
@@ -45,7 +45,7 @@ namespace ffmpegkit {
             static constexpr const char* FFmpegKitVersion = "6.0";
 
             /**
-             * Prefix of named pipes created by ffmpeg-kit.
+             * Prefix of named pipes created by ffmpeg-kit-lib.
              */
             static constexpr const char* FFmpegKitNamedPipePrefix = "fk_pipe_";
 

--- a/linux/src/fftools_cmdutils.c
+++ b/linux/src/fftools_cmdutils.c
@@ -24,15 +24,15 @@
 /*
  * This file is the modified version of cmdutils.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_cmdutils.h
+++ b/linux/src/fftools_cmdutils.h
@@ -24,15 +24,15 @@
 /*
  * This file is the modified version of cmdutils.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg.c
+++ b/linux/src/fftools_ffmpeg.c
@@ -28,9 +28,9 @@
 /*
  * This file is the modified version of ffmpeg.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 09.2023
  * --------------------------------------------------------
@@ -44,7 +44,7 @@
  * - forward_report method signature updated
  * - time field in report_callback/forward_report/set_report_callback updated as double
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg.h
+++ b/linux/src/fftools_ffmpeg.h
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -33,7 +33,7 @@
  * - "class" member field renamed as clazz
  * - time field in set_report_callback updated as double
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_demux.c
+++ b/linux/src/fftools_ffmpeg_demux.c
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg_demux.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_filter.c
+++ b/linux/src/fftools_ffmpeg_filter.c
@@ -23,15 +23,15 @@
 /*
  * This file is the modified version of ffmpeg_filter.c file living in ffmpeg source code under the fftools folder.
  * We manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 08.2018
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_hw.c
+++ b/linux/src/fftools_ffmpeg_hw.c
@@ -22,15 +22,15 @@
 /*
  * This file is the modified version of ffmpeg_hw.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 12.2019
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_mux.c
+++ b/linux/src/fftools_ffmpeg_mux.c
@@ -21,9 +21,9 @@
 /*
  * This file is the modified version of ffmpeg_mux.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -32,7 +32,7 @@
  * - want_sdp marked as thread-local
  * - ms_from_ost migrated from ffmpeg_mux.c and marked as non-static
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_mux.h
+++ b/linux/src/fftools_ffmpeg_mux.h
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of ffmpeg_mux.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_mux_init.c
+++ b/linux/src/fftools_ffmpeg_mux_init.c
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of ffmpeg_mux_init.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_ffmpeg_opt.c
+++ b/linux/src/fftools_ffmpeg_opt.c
@@ -23,9 +23,9 @@
 /*
  * This file is the modified version of ffmpeg_opt.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
@@ -33,7 +33,7 @@
  * - include fftools_ffmpeg_mux.h added
  * - fftools header names updated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 08.2020
  * --------------------------------------------------------

--- a/linux/src/fftools_ffprobe.c
+++ b/linux/src/fftools_ffprobe.c
@@ -28,16 +28,16 @@
 /*
  * This file is the modified version of ffprobe.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop mobile-ffmpeg and later ffmpeg-kit libraries.
+ * by us to develop mobile-ffmpeg and later ffmpeg-kit-lib libraries.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - FFmpeg 6.0 changes migrated
  * - fftools header names updated
  *
- * mobile-ffmpeg / ffmpeg-kit changes by Taner Sener
+ * mobile-ffmpeg / ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_fopen_utf8.h
+++ b/linux/src/fftools_fopen_utf8.h
@@ -19,9 +19,9 @@
 /*
  * This file is the modified version of fopen_utf8.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  */
 
 #ifndef FFTOOLS_FOPEN_UTF8_H

--- a/linux/src/fftools_objpool.c
+++ b/linux/src/fftools_objpool.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of objpool.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_objpool.h
+++ b/linux/src/fftools_objpool.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of objpool.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_opt_common.c
+++ b/linux/src/fftools_opt_common.c
@@ -23,15 +23,15 @@
 /*
  * This file is the modified version of opt_common.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------
  * - time field in report_callback updated as double
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_opt_common.h
+++ b/linux/src/fftools_opt_common.h
@@ -22,9 +22,9 @@
 /*
  * This file is the modified version of opt_common.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop the ffmpeg-kit library.
+ * by us to develop the ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by Taner Sener
+ * ffmpeg-kit-lib changes by Taner Sener
  *
  * 09.2022
  * --------------------------------------------------------

--- a/linux/src/fftools_sync_queue.c
+++ b/linux/src/fftools_sync_queue.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of sync_queue.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_sync_queue.h
+++ b/linux/src/fftools_sync_queue.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of sync_queue.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_thread_queue.c
+++ b/linux/src/fftools_thread_queue.c
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of thread_queue.c file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/linux/src/fftools_thread_queue.h
+++ b/linux/src/fftools_thread_queue.h
@@ -20,9 +20,9 @@
 /*
  * This file is the modified version of thread_queue.h file living in ffmpeg source code under the fftools folder. We
  * manually update it each time we depend on a new ffmpeg version. Below you can see the list of changes applied
- * by us to develop ffmpeg-kit library.
+ * by us to develop ffmpeg-kit-lib library.
  *
- * ffmpeg-kit changes by ARTHENICA LTD
+ * ffmpeg-kit-lib changes by ARTHENICA LTD
  *
  * 07.2023
  * --------------------------------------------------------

--- a/macos.sh
+++ b/macos.sh
@@ -178,8 +178,8 @@ fi
 # DISABLE NOT SUPPORTED ARCHITECTURES
 disable_macos_architecture_not_supported_on_detected_sdk_version "${ARCH_ARM64}"
 
-echo -e "\nBuilding ffmpeg-kit ${BUILD_TYPE_ID}shared library for macOS\n"
-echo -e -n "INFO: Building ffmpeg-kit ${BUILD_VERSION} ${BUILD_TYPE_ID}for macOS: " 1>>"${BASEDIR}"/build.log 2>&1
+echo -e "\nBuilding ffmpeg-kit-lib ${BUILD_TYPE_ID}shared library for macOS\n"
+echo -e -n "INFO: Building ffmpeg-kit-lib ${BUILD_VERSION} ${BUILD_TYPE_ID}for macOS: " 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "$(date)\n" 1>>"${BASEDIR}"/build.log 2>&1
 
 # PRINT BUILD SUMMARY

--- a/react-native/README.md
+++ b/react-native/README.md
@@ -29,26 +29,26 @@
 ### 2. Installation
 
 ```sh
-yarn add ffmpeg-kit-react-native
+yarn add ffmpeg-kit-lib-react-native
 ```
 
 #### 2.1 Packages
 
 `FFmpeg` includes built-in encoders for some popular formats. However, there are certain external libraries that needs
 to be enabled in order to encode specific formats/codecs. For example, to encode an `mp3` file you need `lame` or
-`shine` library enabled. You have to install a `ffmpeg-kit-react-native` package that has at least one of them inside.
+`shine` library enabled. You have to install a `ffmpeg-kit-lib-react-native` package that has at least one of them inside.
 To encode an `h264` video, you need to install a package with `x264` inside. To encode `vp8` or `vp9` videos, you need
-a `ffmpeg-kit-react-native` package with `libvpx` inside.
+a `ffmpeg-kit-lib-react-native` package with `libvpx` inside.
 
-`ffmpeg-kit` provides eight packages that include different sets of external libraries. These packages are named
+`ffmpeg-kit-lib` provides eight packages that include different sets of external libraries. These packages are named
 according to the external libraries included. Refer to the
-[Packages](https://github.com/arthenica/ffmpeg-kit/wiki/Packages) wiki page to see the names of those
+[Packages](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Packages) wiki page to see the names of those
 packages and external libraries included in each one of them.
 
 ##### 2.1.1 Package Names
 
 The following table shows all package names and their respective API levels, iOS deployment targets defined in
-`ffmpeg-kit-react-native`.
+`ffmpeg-kit-lib-react-native`.
 
 <table>
 <thead>
@@ -147,7 +147,7 @@ The following table shows all package names and their respective API levels, iOS
 
 #### 2.2 Enabling Packages
 
-Installing `ffmpeg-kit-react-native` enables the `https` package by default. It is possible to enable other
+Installing `ffmpeg-kit-lib-react-native` enables the `https` package by default. It is possible to enable other
 packages using the instructions below.
 
 ##### 2.2.1 Enabling a Package on Android
@@ -166,17 +166,17 @@ packages using the instructions below.
 - Edit `ios/Podfile` file and add the package name as `subspec`. After that run `pod install` again.
 
     ```ruby
-    pod 'ffmpeg-kit-react-native', :subspecs => ['<package name>'], :podspec => '../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec'
+    pod 'ffmpeg-kit-lib-react-native', :subspecs => ['<package name>'], :podspec => '../node_modules/ffmpeg-kit-lib-react-native/ffmpeg-kit-lib-react-native.podspec'
     ```
 
 - Note that if you have `use_native_modules!` in your `Podfile`, specifying a `subspec` may cause the following error.
-  You can fix it by defining `ffmpeg-kit-react-native` dependency before `use_native_modules!` in your `Podfile`.
+  You can fix it by defining `ffmpeg-kit-lib-react-native` dependency before `use_native_modules!` in your `Podfile`.
 
   ```
-  [!] There are multiple dependencies with different sources for `ffmpeg-kit-react-native` in `Podfile`:
+  [!] There are multiple dependencies with different sources for `ffmpeg-kit-lib-react-native` in `Podfile`:
 
-  - ffmpeg-kit-react-native (from `../node_modules/ffmpeg-kit-react-native`)
-  - ffmpeg-kit-react-native/video (from `../node_modules/ffmpeg-kit-react-native/ffmpeg-kit-react-native.podspec`)
+  - ffmpeg-kit-lib-react-native (from `../node_modules/ffmpeg-kit-lib-react-native`)
+  - ffmpeg-kit-lib-react-native/video (from `../node_modules/ffmpeg-kit-lib-react-native/ffmpeg-kit-lib-react-native.podspec`)
   ```
 
 #### 2.3 Enabling LTS Releases
@@ -186,9 +186,9 @@ the package name you are using.
 
 #### 2.4 LTS Releases
 
-`ffmpeg-kit-react-native` is published in two variants: `Main Release` and `LTS Release`. Both releases share the
+`ffmpeg-kit-lib-react-native` is published in two variants: `Main Release` and `LTS Release`. Both releases share the
 same source code but is built with different settings (Architectures, API Level, iOS Min SDK, etc.). Refer to the
-[LTS Releases](https://github.com/arthenica/ffmpeg-kit/wiki/LTS-Releases) wiki page to see how they differ from each
+[LTS Releases](https://github.com/arthenica/ffmpeg-kit-lib/wiki/LTS-Releases) wiki page to see how they differ from each
 other.
 
 ### 3. Using
@@ -196,7 +196,7 @@ other.
 1. Execute FFmpeg commands.
 
     ```js
-    import { FFmpegKit } from 'ffmpeg-kit-react-native';
+    import { FFmpegKit } from 'ffmpeg-kit-lib-react-native';
 
     FFmpegKit.execute('-i file1.mp4 -c:v mpeg4 file2.mp4').then(async (session) => {
       const returnCode = await session.getReturnCode();
@@ -399,16 +399,16 @@ other.
 ### 4. Test Application
 
 You can see how `FFmpegKit` is used inside an application by running `react-native` test applications developed under
-the [FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-test) project.
+the [FFmpegKit Test](https://github.com/arthenica/ffmpeg-kit-lib-test) project.
 
 ### 5. Tips
 
-See [Tips](https://github.com/arthenica/ffmpeg-kit/wiki/Tips) wiki page.
+See [Tips](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Tips) wiki page.
 
 ### 6. License
 
-See [License](https://github.com/arthenica/ffmpeg-kit/wiki/License) wiki page.
+See [License](https://github.com/arthenica/ffmpeg-kit-lib/wiki/License) wiki page.
 
 ### 7. Patents
 
-See [Patents](https://github.com/arthenica/ffmpeg-kit/wiki/Patents) wiki page.
+See [Patents](https://github.com/arthenica/ffmpeg-kit-lib/wiki/Patents) wiki page.

--- a/react-native/android/build.gradle
+++ b/react-native/android/build.gradle
@@ -125,5 +125,5 @@ repositories {
 
 dependencies {
   api 'com.facebook.react:react-native:+'
-  implementation 'com.arthenica:ffmpeg-kit-' + safePackageName(safeExtGet('ffmpegKitPackage', 'https')) + ':' + safePackageVersion(safeExtGet('ffmpegKitPackage', 'https'))
+  implementation 'com.arthenica:ffmpeg-kit-lib-' + safePackageName(safeExtGet('ffmpegKitPackage', 'https')) + ':' + safePackageVersion(safeExtGet('ffmpegKitPackage', 'https'))
 }

--- a/react-native/android/src/main/java/com/arthenica/ffmpegkit/reactnative/FFmpegKitReactNativeModule.java
+++ b/react-native/android/src/main/java/com/arthenica/ffmpegkit/reactnative/FFmpegKitReactNativeModule.java
@@ -76,7 +76,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FFmpegKitReactNativeModule extends ReactContextBaseJavaModule {
 
-  public static final String LIBRARY_NAME = "ffmpeg-kit-react-native";
+  public static final String LIBRARY_NAME = "ffmpeg-kit-lib-react-native";
   public static final String PLATFORM_NAME = "android";
 
   // LOG CLASS

--- a/react-native/ffmpeg-kit-react-native.podspec
+++ b/react-native/ffmpeg-kit-react-native.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.requires_arc      = true
   s.static_framework  = true
 
-  s.source       = { :git => "https://github.com/arthenica/ffmpeg-kit.git", :tag => "react.native.v#{s.version}" }
+  s.source       = { :git => "https://github.com/arthenica/ffmpeg-kit-lib.git", :tag => "react.native.v#{s.version}" }
 
   s.default_subspec   = 'https'
 
@@ -23,112 +23,112 @@ Pod::Spec.new do |s|
   s.subspec 'min' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-min', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-min', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'min-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-min', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-min', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'min-gpl' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-min-gpl', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-min-gpl', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'min-gpl-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-min-gpl', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-min-gpl', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'https' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-https', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-https', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'https-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-https', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-https', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'https-gpl' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-https-gpl', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-https-gpl', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'https-gpl-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-https-gpl', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-https-gpl', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'audio' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-audio', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-audio', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'audio-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-audio', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-audio', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'video' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-video', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-video', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'video-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-video', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-video', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'full' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-full', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-full', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'full-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-full', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-full', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 
   s.subspec 'full-gpl' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-full-gpl', "6.0"
+      ss.dependency 'ffmpeg-kit-lib-ios-full-gpl', "6.0"
       ss.ios.deployment_target = '12.1'
   end
 
   s.subspec 'full-gpl-lts' do |ss|
       ss.source_files      = '**/FFmpegKitReactNativeModule.m',
                              '**/FFmpegKitReactNativeModule.h'
-      ss.dependency 'ffmpeg-kit-ios-full-gpl', "6.0.LTS"
+      ss.dependency 'ffmpeg-kit-lib-ios-full-gpl', "6.0.LTS"
       ss.ios.deployment_target = '10'
   end
 

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ffmpeg-kit-react-native",
+  "name": "ffmpeg-kit-lib-react-native",
   "version": "6.0.2",
   "description": "FFmpeg Kit for React Native",
   "main": "src/index",
@@ -15,16 +15,16 @@
     "react-native",
     "android",
     "ffmpeg",
-    "ffmpeg-kit",
+    "ffmpeg-kit-lib",
     "ios"
   ],
-  "repository": "https://github.com/arthenica/ffmpeg-kit",
+  "repository": "https://github.com/arthenica/ffmpeg-kit-lib",
   "author": "ARTHENICA <open-source@arthenica.com> (https://www.arthenica.com)",
   "license": "LGPL-3.0",
   "bugs": {
-    "url": "https://github.com/arthenica/ffmpeg-kit/issues"
+    "url": "https://github.com/arthenica/ffmpeg-kit-lib/issues"
   },
-  "homepage": "https://github.com/arthenica/ffmpeg-kit",
+  "homepage": "https://github.com/arthenica/ffmpeg-kit-lib",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },

--- a/react-native/src/index.d.ts
+++ b/react-native/src/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'ffmpeg-kit-react-native' {
+declare module 'ffmpeg-kit-lib-react-native' {
 
   export abstract class AbstractSession implements Session {
 

--- a/react-native/src/index.js
+++ b/react-native/src/index.js
@@ -1904,7 +1904,7 @@ class FFmpegKitInitializer {
       this.#initialized = true;
     }
 
-    console.log("Loading ffmpeg-kit-react-native.");
+    console.log("Loading ffmpeg-kit-lib-react-native.");
 
     this.#eventEmitter.addListener(eventLogCallbackEvent, FFmpegKitInitializer.processLogCallbackEvent);
     this.#eventEmitter.addListener(eventStatisticsCallbackEvent, FFmpegKitInitializer.processStatisticsCallbackEvent);
@@ -1918,7 +1918,7 @@ class FFmpegKitInitializer {
     await FFmpegKitConfig.enableRedirection();
     const isLTSPostfix = (await FFmpegKitConfig.isLTSBuild()) ? "-lts" : "";
 
-    console.log(`Loaded ffmpeg-kit-react-native-${platform}-${packageName}-${arch}-${version}${isLTSPostfix}.`);
+    console.log(`Loaded ffmpeg-kit-lib-react-native-${platform}-${packageName}-${arch}-${version}${isLTSPostfix}.`);
   }
 
 }

--- a/scripts/android/ffmpeg.sh
+++ b/scripts/android/ffmpeg.sh
@@ -342,7 +342,7 @@ export LDFLAGS+=" -L${ANDROID_NDK_ROOT}/platforms/android-${API}/arch-${TOOLCHAI
 
 # LINKING WITH ANDROID LTS SUPPORT LIBRARY IS NECESSARY FOR API < 18
 if [[ -n ${FFMPEG_KIT_LTS_BUILD} ]] && [[ ${API} -lt 18 ]]; then
-  export LDFLAGS+=" -Wl,--whole-archive ${BASEDIR}/android/ffmpeg-kit-android-lib/src/main/cpp/libandroidltssupport.a -Wl,--no-whole-archive"
+  export LDFLAGS+=" -Wl,--whole-archive ${BASEDIR}/android/ffmpeg-kit-lib-android-lib/src/main/cpp/libandroidltssupport.a -Wl,--no-whole-archive"
 fi
 
 # ALWAYS BUILD SHARED LIBRARIES
@@ -390,7 +390,7 @@ ulimit -n 2048 1>>"${BASEDIR}"/build.log 2>&1
 
 ########################### CUSTOMIZATIONS #######################
 cd "${BASEDIR}" 1>>"${BASEDIR}"/build.log 2>&1 || return 1
-git checkout android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.c 1>>"${BASEDIR}"/build.log 2>&1
+git checkout android/ffmpeg-kit-lib-android-lib/src/main/cpp/ffmpegkit.c 1>>"${BASEDIR}"/build.log 2>&1
 cd "${BASEDIR}"/src/"${LIB_NAME}" 1>>"${BASEDIR}"/build.log 2>&1 || return 1
 git checkout libavformat/file.c 1>>"${BASEDIR}"/build.log 2>&1
 git checkout libavformat/protocols.c 1>>"${BASEDIR}"/build.log 2>&1
@@ -399,17 +399,17 @@ git checkout libavutil 1>>"${BASEDIR}"/build.log 2>&1
 # 1. Use thread local log levels
 ${SED_INLINE} 's/static int av_log_level/__thread int av_log_level/g' "${BASEDIR}"/src/"${LIB_NAME}"/libavutil/log.c 1>>"${BASEDIR}"/build.log 2>&1 || return 1
 
-# 2. Enable ffmpeg-kit protocols
+# 2. Enable ffmpeg-kit-lib protocols
 if [[ ${NO_FFMPEG_KIT_PROTOCOLS} == "1" ]]; then
-  ${SED_INLINE} "s| av_set_saf|//av_set_saf|g" "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.c 1>>"${BASEDIR}"/build.log 2>&1
-  echo -e "\nINFO: Disabled custom ffmpeg-kit protocols\n" 1>>"${BASEDIR}"/build.log 2>&1
+  ${SED_INLINE} "s| av_set_saf|//av_set_saf|g" "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/ffmpegkit.c 1>>"${BASEDIR}"/build.log 2>&1
+  echo -e "\nINFO: Disabled custom ffmpeg-kit-lib protocols\n" 1>>"${BASEDIR}"/build.log 2>&1
 else
   cat ../../tools/protocols/libavformat_file.c >> libavformat/file.c
   cat ../../tools/protocols/libavutil_file.h >> libavutil/file.h
   cat ../../tools/protocols/libavutil_file.c >> libavutil/file.c
   awk '{gsub(/ff_file_protocol;/,"ff_file_protocol;\nextern const URLProtocol ff_saf_protocol;")}1' libavformat/protocols.c > libavformat/protocols.c.tmp
   cat libavformat/protocols.c.tmp > libavformat/protocols.c
-  echo -e "\nINFO: Enabled custom ffmpeg-kit protocols\n" 1>>"${BASEDIR}"/build.log 2>&1
+  echo -e "\nINFO: Enabled custom ffmpeg-kit-lib protocols\n" 1>>"${BASEDIR}"/build.log 2>&1
 fi
 
 ###################################################################

--- a/scripts/android/kvazaar.sh
+++ b/scripts/android/kvazaar.sh
@@ -11,7 +11,7 @@ fi
 # UPDATE BUILD FLAGS
 # LINKING WITH ANDROID LTS SUPPORT LIBRARY IS NECESSARY FOR API < 18
 if [[ -n ${FFMPEG_KIT_LTS_BUILD} ]] && [[ ${API} -lt 18 ]]; then
-  LTS_SUPPORT_LIBS=" -Wl,--no-whole-archive ${BASEDIR}/android/ffmpeg-kit-android-lib/src/main/cpp/libandroidltssupport.a -Wl,--no-whole-archive"
+  LTS_SUPPORT_LIBS=" -Wl,--no-whole-archive ${BASEDIR}/android/ffmpeg-kit-lib-android-lib/src/main/cpp/libandroidltssupport.a -Wl,--no-whole-archive"
 else
   LTS_SUPPORT_LIBS=""
 fi

--- a/scripts/apple/ffmpeg-kit.sh
+++ b/scripts/apple/ffmpeg-kit.sh
@@ -3,7 +3,7 @@
 # ENABLE COMMON FUNCTIONS
 source "${BASEDIR}"/scripts/function-"${FFMPEG_KIT_BUILD_TYPE}".sh 1>>"${BASEDIR}"/build.log 2>&1 || return 1
 
-LIB_NAME="ffmpeg-kit"
+LIB_NAME="ffmpeg-kit-lib"
 
 echo -e "----------------------------------------------------------------" 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "\nINFO: Building ${LIB_NAME} for ${HOST} with the following environment variables\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/scripts/function-android.sh
+++ b/scripts/function-android.sh
@@ -17,7 +17,7 @@ enable_default_android_libraries() {
 }
 
 get_ffmpeg_kit_version() {
-  local FFMPEG_KIT_VERSION=$(grep '#define FFMPEG_KIT_VERSION' "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/ffmpegkit.h | grep -Eo '\".*\"' | sed -e 's/\"//g')
+  local FFMPEG_KIT_VERSION=$(grep '#define FFMPEG_KIT_VERSION' "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/ffmpegkit.h | grep -Eo '\".*\"' | sed -e 's/\"//g')
 
   echo "${FFMPEG_KIT_VERSION}"
 }
@@ -33,7 +33,7 @@ under the prebuilt folder.\n"
   echo -e "Usage: ./$COMMAND [OPTION]... [VAR=VALUE]...\n"
   echo -e "Specify environment variables as VARIABLE=VALUE to override default build options.\n"
 
-  display_help_options "  -l, --lts\t\t\tbuild lts packages to support API 16+ devices" "      --api-level=api\t\toverride Android api level" "      --no-ffmpeg-kit-protocols\tdisable custom ffmpeg-kit protocols (saf)"
+  display_help_options "  -l, --lts\t\t\tbuild lts packages to support API 16+ devices" "      --api-level=api\t\toverride Android api level" "      --no-ffmpeg-kit-lib-protocols\tdisable custom ffmpeg-kit-lib protocols (saf)"
   display_help_licensing
 
   echo -e "Architectures:"
@@ -1070,8 +1070,8 @@ set_toolchain_paths() {
 build_android_lts_support() {
 
   # CLEAN OLD BUILD
-  rm -f "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/android_lts_support.o 1>>"${BASEDIR}"/build.log 2>&1
-  rm -f "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/android_lts_support.a 1>>"${BASEDIR}"/build.log 2>&1
+  rm -f "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/android_lts_support.o 1>>"${BASEDIR}"/build.log 2>&1
+  rm -f "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/android_lts_support.a 1>>"${BASEDIR}"/build.log 2>&1
 
   echo -e "INFO: Building android-lts-support objects for ${ARCH}\n" 1>>"${BASEDIR}"/build.log 2>&1
 
@@ -1085,6 +1085,6 @@ build_android_lts_support() {
   LDFLAGS=$(get_ldflags ${LIB_NAME})
 
   # BUILD
-  "${CC}" ${CFLAGS} -Wno-unused-command-line-argument -c "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/android_lts_support.c -o "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/android_lts_support.o ${LDFLAGS} 1>>"${BASEDIR}"/build.log 2>&1
-  "${AR}" rcs "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/libandroidltssupport.a "${BASEDIR}"/android/ffmpeg-kit-android-lib/src/main/cpp/android_lts_support.o 1>>"${BASEDIR}"/build.log 2>&1
+  "${CC}" ${CFLAGS} -Wno-unused-command-line-argument -c "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/android_lts_support.c -o "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/android_lts_support.o ${LDFLAGS} 1>>"${BASEDIR}"/build.log 2>&1
+  "${AR}" rcs "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/libandroidltssupport.a "${BASEDIR}"/android/ffmpeg-kit-lib-android-lib/src/main/cpp/android_lts_support.o 1>>"${BASEDIR}"/build.log 2>&1
 }

--- a/scripts/function-apple.sh
+++ b/scripts/function-apple.sh
@@ -281,7 +281,7 @@ create_ffmpeg_universal_library() {
 create_ffmpeg_kit_universal_library() {
   local ARCHITECTURE_VARIANT="$1"
   local TARGET_ARCHITECTURES=("$(get_apple_architectures_for_variant "${ARCHITECTURE_VARIANT}")")
-  local LIBRARY_NAME="ffmpeg-kit"
+  local LIBRARY_NAME="ffmpeg-kit-lib"
   local UNIVERSAL_LIBRARY_DIRECTORY="${BASEDIR}/.tmp/$(get_universal_library_directory "${ARCHITECTURE_VARIANT}")"
   local FFMPEG_KIT_UNIVERSAL_LIBRARY_DIRECTORY="${UNIVERSAL_LIBRARY_DIRECTORY}/${LIBRARY_NAME}"
   local LIPO="$(xcrun --sdk "$(get_default_sdk_name)" -f lipo)"
@@ -297,7 +297,7 @@ create_ffmpeg_kit_universal_library() {
   initialize_folder "${FFMPEG_KIT_UNIVERSAL_LIBRARY_DIRECTORY}/include"
   initialize_folder "${FFMPEG_KIT_UNIVERSAL_LIBRARY_DIRECTORY}/lib"
 
-  local FFMPEG_KIT_DEFAULT_BUILD_PATH="${BASEDIR}/prebuilt/$(get_default_build_directory)/ffmpeg-kit"
+  local FFMPEG_KIT_DEFAULT_BUILD_PATH="${BASEDIR}/prebuilt/$(get_default_build_directory)/ffmpeg-kit-lib"
 
   # COPY HEADER FILES
   cp -r "${FFMPEG_KIT_DEFAULT_BUILD_PATH}"/include/* "${FFMPEG_KIT_UNIVERSAL_LIBRARY_DIRECTORY}"/include 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
@@ -447,7 +447,7 @@ create_ffmpeg_framework() {
 #
 create_ffmpeg_kit_framework() {
   local ARCHITECTURE_VARIANT="$1"
-  local LIBRARY_NAME="ffmpeg-kit"
+  local LIBRARY_NAME="ffmpeg-kit-lib"
   local UNIVERSAL_LIBRARY_DIRECTORY="${BASEDIR}/.tmp/$(get_universal_library_directory "${ARCHITECTURE_VARIANT}")"
   local FFMPEG_KIT_UNIVERSAL_LIBRARY_DIRECTORY="${UNIVERSAL_LIBRARY_DIRECTORY}/${LIBRARY_NAME}"
 
@@ -518,7 +518,7 @@ create_ffmpeg_kit_framework() {
   build_info_plist "${FFMPEG_KIT_FRAMEWORK_RESOURCE_PATH}/Info.plist" "ffmpegkit" "com.arthenica.ffmpegkit.FFmpegKit" "${FFMPEG_KIT_VERSION}" "${FFMPEG_KIT_VERSION}" "${ARCHITECTURE_VARIANT}"
   build_modulemap "${FFMPEG_KIT_FRAMEWORK_PATH}/Modules/module.modulemap"
 
-  echo -e "DEBUG: ffmpeg-kit framework built for $(get_apple_architecture_variant "${ARCHITECTURE_VARIANT}") platform successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
+  echo -e "DEBUG: ffmpeg-kit-lib framework built for $(get_apple_architecture_variant "${ARCHITECTURE_VARIANT}") platform successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
 }
 
 create_ffmpeg_xcframework() {
@@ -591,7 +591,7 @@ create_ffmpeg_kit_xcframework() {
     exit_xcframework "${FRAMEWORK_NAME}"
   fi
 
-  echo -e "DEBUG: xcframework for ffmpeg-kit built successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
+  echo -e "DEBUG: xcframework for ffmpeg-kit-lib built successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
 }
 
 #

--- a/scripts/function-ios.sh
+++ b/scripts/function-ios.sh
@@ -205,7 +205,7 @@ get_app_specific_cflags() {
   ffmpeg)
     APP_FLAGS="-Wno-unused-function -Wno-deprecated-declarations"
     ;;
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     APP_FLAGS="-std=c99 -Wno-unused-function -Wall -Wno-deprecated-declarations -Wno-pointer-sign -Wno-switch -Wno-unused-result -Wno-unused-variable -DPIC -fobjc-arc"
     ;;
   gnutls)
@@ -333,7 +333,7 @@ get_size_optimization_ldflags() {
   case ${ARCH} in
   armv7 | armv7s | arm64 | arm64e | *-mac-catalyst)
     case $1 in
-    ffmpeg | ffmpeg-kit)
+    ffmpeg | ffmpeg-kit-lib)
       echo "-Oz -dead_strip"
       ;;
     *)
@@ -400,7 +400,7 @@ get_ldflags() {
   fi
 
   case $1 in
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     case ${ARCH} in
     armv7 | armv7s | arm64 | arm64e | *-mac-catalyst)
       echo "${ARCH_FLAGS} ${LINKED_LIBRARIES} ${COMMON_FLAGS} ${BITCODE_FLAGS} ${OPTIMIZATION_FLAGS}"
@@ -426,7 +426,7 @@ set_toolchain_paths() {
     (chmod +x "${FFMPEG_KIT_TMPDIR}"/gas-preprocessor.pl 1>>"${BASEDIR}"/build.log 2>&1) || return 1
 
     # patch gas-preprocessor.pl against the following warning
-    # Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/(?:ld|st)\d\s+({ <-- HERE \s*v(\d+)\.(\d[bhsdBHSD])\s*-\s*v(\d+)\.(\d[bhsdBHSD])\s*})/ at /Users/taner/Projects/ffmpeg-kit/.tmp/gas-preprocessor.pl line 1065.
+    # Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/(?:ld|st)\d\s+({ <-- HERE \s*v(\d+)\.(\d[bhsdBHSD])\s*-\s*v(\d+)\.(\d[bhsdBHSD])\s*})/ at /Users/taner/Projects/ffmpeg-kit-lib/.tmp/gas-preprocessor.pl line 1065.
     sed -i .tmp "s/s\+({/s\+(\\\\{/g;s/s\*})/s\*\\\\})/g" "${FFMPEG_KIT_TMPDIR}"/gas-preprocessor.pl
   fi
 

--- a/scripts/function-linux.sh
+++ b/scripts/function-linux.sh
@@ -110,8 +110,8 @@ install_pkg_config_file() {
   fi
 
   # UPDATE PATHS
-  ${SED_INLINE} "s|${LIB_INSTALL_BASE}/ffmpeg-kit|${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit|g" "$DESTINATION" 1>>"${BASEDIR}"/build.log 2>&1 || return 1
-  ${SED_INLINE} "s|${LIB_INSTALL_BASE}/ffmpeg|${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit|g" "$DESTINATION" 1>>"${BASEDIR}"/build.log 2>&1 || return 1
+  ${SED_INLINE} "s|${LIB_INSTALL_BASE}/ffmpeg-kit-lib|${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib|g" "$DESTINATION" 1>>"${BASEDIR}"/build.log 2>&1 || return 1
+  ${SED_INLINE} "s|${LIB_INSTALL_BASE}/ffmpeg|${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib|g" "$DESTINATION" 1>>"${BASEDIR}"/build.log 2>&1 || return 1
 }
 
 get_bundle_directory() {
@@ -128,22 +128,22 @@ create_linux_bundle() {
 
   local FFMPEG_KIT_VERSION=$(get_ffmpeg_kit_version)
 
-  local FFMPEG_KIT_BUNDLE_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit"
-  local FFMPEG_KIT_BUNDLE_INCLUDE_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/include"
-  local FFMPEG_KIT_BUNDLE_LIB_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/lib"
-  local FFMPEG_KIT_BUNDLE_PKG_CONFIG_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/pkgconfig"
+  local FFMPEG_KIT_BUNDLE_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib"
+  local FFMPEG_KIT_BUNDLE_INCLUDE_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/include"
+  local FFMPEG_KIT_BUNDLE_LIB_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/lib"
+  local FFMPEG_KIT_BUNDLE_PKG_CONFIG_DIRECTORY="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/pkgconfig"
 
   initialize_folder "${FFMPEG_KIT_BUNDLE_INCLUDE_DIRECTORY}"
   initialize_folder "${FFMPEG_KIT_BUNDLE_LIB_DIRECTORY}"
   initialize_folder "${FFMPEG_KIT_BUNDLE_PKG_CONFIG_DIRECTORY}"
 
   # COPY HEADERS
-  cp -r -P "${LIB_INSTALL_BASE}"/ffmpeg-kit/include/* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/include" 2>>"${BASEDIR}"/build.log
-  cp -r -P "${LIB_INSTALL_BASE}"/ffmpeg/include/* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/include" 2>>"${BASEDIR}"/build.log
+  cp -r -P "${LIB_INSTALL_BASE}"/ffmpeg-kit-lib/include/* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/include" 2>>"${BASEDIR}"/build.log
+  cp -r -P "${LIB_INSTALL_BASE}"/ffmpeg/include/* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/include" 2>>"${BASEDIR}"/build.log
 
   # COPY LIBS
-  cp -P "${LIB_INSTALL_BASE}"/ffmpeg-kit/lib/lib* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/lib" 2>>"${BASEDIR}"/build.log
-  cp -P "${LIB_INSTALL_BASE}"/ffmpeg/lib/lib* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/lib" 2>>"${BASEDIR}"/build.log
+  cp -P "${LIB_INSTALL_BASE}"/ffmpeg-kit-lib/lib/lib* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/lib" 2>>"${BASEDIR}"/build.log
+  cp -P "${LIB_INSTALL_BASE}"/ffmpeg/lib/lib* "${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/lib" 2>>"${BASEDIR}"/build.log
 
   install_pkg_config_file "libavformat.pc"
   install_pkg_config_file "libswresample.pc"
@@ -152,10 +152,10 @@ create_linux_bundle() {
   install_pkg_config_file "libavfilter.pc"
   install_pkg_config_file "libavcodec.pc"
   install_pkg_config_file "libavutil.pc"
-  install_pkg_config_file "ffmpeg-kit.pc"
+  install_pkg_config_file "ffmpeg-kit-lib.pc"
 
   # COPY EXTERNAL LIBRARY LICENSES
-  LICENSE_BASEDIR="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit/lib"
+  LICENSE_BASEDIR="${BASEDIR}/prebuilt/$(get_bundle_directory)/ffmpeg-kit-lib/lib"
   rm -f "${LICENSE_BASEDIR}"/*.txt 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
   for library in {0..49}; do
     if [[ ${ENABLED_LIBRARIES[$library]} -eq 1 ]]; then
@@ -203,7 +203,7 @@ create_linux_bundle() {
 
   cp "${BASEDIR}"/tools/source/SOURCE "${LICENSE_BASEDIR}"/source.txt 1>>"${BASEDIR}"/build.log 2>&1 || exit 1
 
-  echo -e "DEBUG: Copied the ffmpeg-kit license successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
+  echo -e "DEBUG: Copied the ffmpeg-kit-lib license successfully\n" 1>>"${BASEDIR}"/build.log 2>&1
 }
 
 get_cmake_system_processor() {
@@ -274,7 +274,7 @@ get_app_specific_cflags() {
   ffmpeg)
     APP_FLAGS="-Wno-unused-function"
     ;;
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     APP_FLAGS="-Wno-unused-function -Wno-pointer-sign -Wno-switch -Wno-deprecated-declarations"
     ;;
   kvazaar)
@@ -332,7 +332,7 @@ get_cxxflags() {
       echo "${FFMPEG_KIT_DEBUG} -stdlib=libstdc++ -std=c++11"
     fi
     ;;
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     echo "${COMMON_FLAGS}"
     ;;
   srt | tesseract | zimg)
@@ -348,7 +348,7 @@ get_common_linked_libraries() {
   local COMMON_LIBRARIES=""
 
   case $1 in
-  chromaprint | ffmpeg-kit | kvazaar | srt | zimg)
+  chromaprint | ffmpeg-kit-lib | kvazaar | srt | zimg)
     echo "-stdlib=libstdc++ -lstdc++ -lc -lm ${COMMON_LIBRARIES}"
     ;;
   *)
@@ -443,13 +443,13 @@ EOF
 create_ffmpegkit_package_config() {
   local FFMPEGKIT_VERSION="$1"
 
-  cat >"${INSTALL_PKG_CONFIG_DIR}/ffmpeg-kit.pc" <<EOF
-prefix=${LIB_INSTALL_BASE}/ffmpeg-kit
+  cat >"${INSTALL_PKG_CONFIG_DIR}/ffmpeg-kit-lib.pc" <<EOF
+prefix=${LIB_INSTALL_BASE}/ffmpeg-kit-lib
 exec_prefix=\${prefix}
 libdir=\${exec_prefix}/lib
 includedir=\${prefix}/include
 
-Name: ffmpeg-kit
+Name: ffmpeg-kit-lib
 Description: FFmpeg for applications
 Version: ${FFMPEGKIT_VERSION}
 

--- a/scripts/function-macos.sh
+++ b/scripts/function-macos.sh
@@ -142,7 +142,7 @@ get_app_specific_cflags() {
   ffmpeg)
     APP_FLAGS="-Wno-unused-function -Wno-deprecated-declarations"
     ;;
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     APP_FLAGS="-std=c99 -Wno-unused-function -Wall -Wno-deprecated-declarations -Wno-pointer-sign -Wno-switch -Wno-unused-result -Wno-unused-variable -DPIC -fobjc-arc"
     ;;
   fontconfig)
@@ -266,7 +266,7 @@ get_size_optimization_ldflags() {
   case ${ARCH} in
   arm64 | x86-64)
     case $1 in
-    ffmpeg | ffmpeg-kit)
+    ffmpeg | ffmpeg-kit-lib)
       echo "-Oz -dead_strip"
       ;;
     *)
@@ -299,7 +299,7 @@ get_ldflags() {
   local COMMON_FLAGS=$(get_common_ldflags)
 
   case $1 in
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     case ${ARCH} in
     arm64)
       echo "${ARCH_FLAGS} ${LINKED_LIBRARIES} ${COMMON_FLAGS} ${OPTIMIZATION_FLAGS}"
@@ -324,7 +324,7 @@ set_toolchain_paths() {
     (chmod +x "${FFMPEG_KIT_TMPDIR}"/gas-preprocessor.pl 1>>"${BASEDIR}"/build.log 2>&1) || return 1
 
     # patch gas-preprocessor.pl against the following warning
-    # Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/(?:ld|st)\d\s+({ <-- HERE \s*v(\d+)\.(\d[bhsdBHSD])\s*-\s*v(\d+)\.(\d[bhsdBHSD])\s*})/ at /Users/taner/Projects/ffmpeg-kit/.tmp/gas-preprocessor.pl line 1065.
+    # Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/(?:ld|st)\d\s+({ <-- HERE \s*v(\d+)\.(\d[bhsdBHSD])\s*-\s*v(\d+)\.(\d[bhsdBHSD])\s*})/ at /Users/taner/Projects/ffmpeg-kit-lib/.tmp/gas-preprocessor.pl line 1065.
     sed -i .tmp "s/s\+({/s\+(\\\\{/g;s/s\*})/s\*\\\\})/g" "${FFMPEG_KIT_TMPDIR}"/gas-preprocessor.pl
   fi
 

--- a/scripts/function-tvos.sh
+++ b/scripts/function-tvos.sh
@@ -116,7 +116,7 @@ get_size_optimization_cflags() {
     x264 | x265)
       ARCH_OPTIMIZATION="-Oz -Wno-ignored-optimization-argument"
       ;;
-    ffmpeg | ffmpeg-kit)
+    ffmpeg | ffmpeg-kit-lib)
       ARCH_OPTIMIZATION="-Oz -Wno-ignored-optimization-argument"
       ;;
     *)
@@ -181,7 +181,7 @@ get_app_specific_cflags() {
   ffmpeg)
     APP_FLAGS="-Wno-unused-function -Wno-deprecated-declarations"
     ;;
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     APP_FLAGS="-std=c99 -Wno-unused-function -Wall -Wno-deprecated-declarations -Wno-pointer-sign -Wno-switch -Wno-unused-result -Wno-unused-variable -DPIC -fobjc-arc"
     ;;
   gnutls)
@@ -309,7 +309,7 @@ get_size_optimization_ldflags() {
   case ${ARCH} in
   arm64)
     case $1 in
-    ffmpeg | ffmpeg-kit)
+    ffmpeg | ffmpeg-kit-lib)
       echo "-Oz -dead_strip"
       ;;
     *)
@@ -362,7 +362,7 @@ get_ldflags() {
   fi
 
   case $1 in
-  ffmpeg-kit)
+  ffmpeg-kit-lib)
     case ${ARCH} in
     arm64)
       echo "${ARCH_FLAGS} ${LINKED_LIBRARIES} ${COMMON_FLAGS} ${BITCODE_FLAGS} ${OPTIMIZATION_FLAGS}"
@@ -388,7 +388,7 @@ set_toolchain_paths() {
     (chmod +x "${FFMPEG_KIT_TMPDIR}"/gas-preprocessor.pl 1>>"${BASEDIR}"/build.log 2>&1) || return 1
 
     # patch gas-preprocessor.pl against the following warning
-    # Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/(?:ld|st)\d\s+({ <-- HERE \s*v(\d+)\.(\d[bhsdBHSD])\s*-\s*v(\d+)\.(\d[bhsdBHSD])\s*})/ at /Users/taner/Projects/ffmpeg-kit/.tmp/gas-preprocessor.pl line 1065.
+    # Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.32), passed through in regex; marked by <-- HERE in m/(?:ld|st)\d\s+({ <-- HERE \s*v(\d+)\.(\d[bhsdBHSD])\s*-\s*v(\d+)\.(\d[bhsdBHSD])\s*})/ at /Users/taner/Projects/ffmpeg-kit-lib/.tmp/gas-preprocessor.pl line 1065.
     sed -i .tmp "s/s\+({/s\+(\\\\{/g;s/s\*})/s\*\\\\})/g" "${FFMPEG_KIT_TMPDIR}"/gas-preprocessor.pl
   fi
 

--- a/scripts/function.sh
+++ b/scripts/function.sh
@@ -1643,7 +1643,7 @@ print_enabled_xcframeworks() {
     echo -n "${FFMPEG_LIB}, "
   done
 
-  echo "ffmpeg-kit"
+  echo "ffmpeg-kit-lib"
 }
 
 print_reconfigure_requested_libraries() {

--- a/scripts/linux/ffmpeg-kit.sh
+++ b/scripts/linux/ffmpeg-kit.sh
@@ -3,7 +3,7 @@
 # ENABLE COMMON FUNCTIONS
 source "${BASEDIR}"/scripts/function-"${FFMPEG_KIT_BUILD_TYPE}".sh 1>>"${BASEDIR}"/build.log 2>&1 || return 1
 
-LIB_NAME="ffmpeg-kit"
+LIB_NAME="ffmpeg-kit-lib"
 
 echo -e "----------------------------------------------------------------" 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "\nINFO: Building ${LIB_NAME} for ${HOST} with the following environment variables\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/scripts/main-ios.sh
+++ b/scripts/main-ios.sh
@@ -240,9 +240,9 @@ fi
 if [[ ${SKIP_ffmpeg_kit} -ne 1 ]]; then
 
   # BUILD FFMPEG KIT
-  . "${BASEDIR}"/scripts/apple/ffmpeg-kit.sh "$@" || return 1
+  . "${BASEDIR}"/scripts/apple/ffmpeg-kit-lib.sh "$@" || return 1
 else
-  echo -e "\nffmpeg-kit: skipped"
+  echo -e "\nffmpeg-kit-lib: skipped"
 fi
 
 echo -e "\nINFO: Completed build for ${ARCH} at $(date)\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/scripts/main-linux.sh
+++ b/scripts/main-linux.sh
@@ -160,9 +160,9 @@ fi
 if [[ ${SKIP_ffmpeg_kit} -ne 1 ]]; then
 
   # BUILD FFMPEG KIT
-  . "${BASEDIR}"/scripts/linux/ffmpeg-kit.sh "$@" || return 1
+  . "${BASEDIR}"/scripts/linux/ffmpeg-kit-lib.sh "$@" || return 1
 else
-  echo -e "\nffmpeg-kit: skipped"
+  echo -e "\nffmpeg-kit-lib: skipped"
 fi
 
 echo -e "\nINFO: Completed build for ${ARCH} at $(date)\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/scripts/main-macos.sh
+++ b/scripts/main-macos.sh
@@ -239,9 +239,9 @@ fi
 if [[ ${SKIP_ffmpeg_kit} -ne 1 ]]; then
 
   # BUILD FFMPEG KIT
-  . "${BASEDIR}"/scripts/apple/ffmpeg-kit.sh "$@" || return 1
+  . "${BASEDIR}"/scripts/apple/ffmpeg-kit-lib.sh "$@" || return 1
 else
-  echo -e "\nffmpeg-kit: skipped"
+  echo -e "\nffmpeg-kit-lib: skipped"
 fi
 
 echo -e "\nINFO: Completed build for ${ARCH} at $(date)\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/scripts/main-tvos.sh
+++ b/scripts/main-tvos.sh
@@ -238,9 +238,9 @@ fi
 if [[ ${SKIP_ffmpeg_kit} -ne 1 ]]; then
 
   # BUILD FFMPEG
-  . "${BASEDIR}"/scripts/apple/ffmpeg-kit.sh "$@" || return 1
+  . "${BASEDIR}"/scripts/apple/ffmpeg-kit-lib.sh "$@" || return 1
 else
-  echo -e "\nffmpeg-kit: skipped"
+  echo -e "\nffmpeg-kit-lib: skipped"
 fi
 
 echo -e "\nINFO: Completed build for ${ARCH} at $(date)\n" 1>>"${BASEDIR}"/build.log 2>&1

--- a/tools/android/build.gradle
+++ b/tools/android/build.gradle
@@ -12,7 +12,7 @@ android {
         targetSdk 33
         versionCode 240600
         versionName "6.0"
-        project.archivesBaseName = "ffmpeg-kit"
+        project.archivesBaseName = "ffmpeg-kit-lib"
         consumerProguardFiles "consumer-rules.pro"
     }
 

--- a/tools/android/build.lts.gradle
+++ b/tools/android/build.lts.gradle
@@ -12,7 +12,7 @@ android {
         targetSdk 33
         versionCode 160600
         versionName "6.0.LTS"
-        project.archivesBaseName = "ffmpeg-kit"
+        project.archivesBaseName = "ffmpeg-kit-lib"
         consumerProguardFiles "consumer-rules.pro"
     }
 

--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -5,7 +5,7 @@ rm -rf ../.tmp
 rm -f ../build.log
 
 rm -rf ../android/build
-rm -rf ../android/ffmpeg-kit-android-lib/build
+rm -rf ../android/ffmpeg-kit-lib-android-lib/build
 rm -rf ../android/obj
 rm -rf ../android/libs
 

--- a/tools/docs/android_doc.sh
+++ b/tools/docs/android_doc.sh
@@ -5,6 +5,6 @@
 
 CURRENT_DIR="`pwd`"
 
-cd "${CURRENT_DIR}"/../../android/ffmpeg-kit-android-lib
+cd "${CURRENT_DIR}"/../../android/ffmpeg-kit-lib-android-lib
 
 doxygen

--- a/tools/docs/android_javadoc.sh
+++ b/tools/docs/android_javadoc.sh
@@ -5,8 +5,8 @@
 
 CURRENT_DIR="`pwd`"
 
-gradle -b "${CURRENT_DIR}"/../../android/ffmpeg-kit-android-lib/build.gradle clean javaDocReleaseGeneration
+gradle -b "${CURRENT_DIR}"/../../android/ffmpeg-kit-lib-android-lib/build.gradle clean javaDocReleaseGeneration
 
 rm -rf "${CURRENT_DIR}"/../../docs/android/javadoc
 
-cp -r "${CURRENT_DIR}"/../../android/ffmpeg-kit-android-lib/build/intermediates/java_doc_dir/release "${CURRENT_DIR}"/../../docs/android/javadoc
+cp -r "${CURRENT_DIR}"/../../android/ffmpeg-kit-lib-android-lib/build/intermediates/java_doc_dir/release "${CURRENT_DIR}"/../../docs/android/javadoc

--- a/tools/source/SOURCE
+++ b/tools/source/SOURCE
@@ -1,6 +1,6 @@
 The source code of "FFmpegKit", "FFmpeg" and external libraries enabled within
 "FFmpeg" for this release can be downloaded from
-https://github.com/arthenica/ffmpeg-kit/wiki/Source page.
+https://github.com/arthenica/ffmpeg-kit-lib/wiki/Source page.
 
 If you want to receive the source code on physical media submit your request
 to "open-source@arthenica.com" email address.

--- a/tvos.sh
+++ b/tvos.sh
@@ -192,8 +192,8 @@ if [[ ${NO_FRAMEWORK} -ne 1 ]] && [[ -z ${FFMPEG_KIT_XCF_BUILD} ]] && [[ ${ENABL
   disable_arch "arm64-simulator"
 fi
 
-echo -e "\nBuilding ffmpeg-kit ${BUILD_TYPE_ID}shared library for tvOS\n"
-echo -e -n "INFO: Building ffmpeg-kit ${BUILD_VERSION} ${BUILD_TYPE_ID}for tvOS: " 1>>"${BASEDIR}"/build.log 2>&1
+echo -e "\nBuilding ffmpeg-kit-lib ${BUILD_TYPE_ID}shared library for tvOS\n"
+echo -e -n "INFO: Building ffmpeg-kit-lib ${BUILD_VERSION} ${BUILD_TYPE_ID}for tvOS: " 1>>"${BASEDIR}"/build.log 2>&1
 echo -e "$(date)\n" 1>>"${BASEDIR}"/build.log 2>&1
 
 # PRINT BUILD SUMMARY


### PR DESCRIPTION
Este PR atualiza todas as referências para os novos nomes de repositórios conforme a padronização.

### Substituições realizadas:
- `ffmpeg-kit` -> `ffmpeg-kit-lib`
- `https://github.com/v3-tecnologia/ffmpeg-kit` -> `https://github.com/v3-tecnologia/ffmpeg-kit-lib`
- `https://github.com/v3-tecnologia/ffmpeg-kit.git` -> `https://github.com/v3-tecnologia/ffmpeg-kit-lib`